### PR TITLE
BDMS-20: automates deployment of staging app to gcp

### DIFF
--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -1,0 +1,60 @@
+name: CD (Dev)
+
+on:
+  push:
+    branches: [pre-production]
+
+jobs:
+    staging-deploy:
+
+        runs-on: ubuntu-latest
+        environment: staging
+
+        steps:
+        - name: Check out source repository
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+
+        - name: Authenticate to Google Cloud
+          uses: 'google-github-actions/auth@v2'
+          with:
+            credentials_json: ${{ secrets.CLOUD_DEPLOY_SERVICE_ACCOUNT_KEY }}
+
+        # Uses Google Cloud Secret Manager to store secret credentials
+        - name: Create app.yaml
+          run: |
+            echo "service: nmsamplelocations" > app.yaml
+            echo "runtime: python310" >> app.yaml
+            echo "entrypoint: gunicorn -w 4 -k uvicorn.workers.UvicornWorker main:app" >> app.yaml
+            echo "instance_class: F4" >> app.yaml
+            echo "" >> app.yaml
+            echo "env_variables:" >> app.yaml
+            echo "  MODE: \"production\"" >> app.yaml
+            echo "  DB_DRIVER: \"cloudsql\"" >> app.yaml
+            echo "" >> app.yaml
+            echo "secret_environment_variables:" >> app.yaml
+            echo "  CLOUD_SQL_INSTANCE_NAME: \"projects/${{ secrets.GCP_PROJECT_ID }}/secrets/nmsample-stage-cloud-sql-instance-name/versions/latest\"" >> app.yaml
+            echo "  CLOUD_SQL_DATABASE: \"projects/${{ secrets.GCP_PROJECT_ID }}/secrets/nmsample-stage-cloud-sql-database/versions/latest\"" >> app.yaml
+            echo "  CLOUD_SQL_USER: \"projects/${{ secrets.GCP_PROJECT_ID }}/secrets/nmsample-stage-cloud-sql-user/versions/latest\"" >> app.yaml
+            echo "  CLOUD_SQL_PASSWORD: \"projects/${{ secrets.GCP_PROJECT_ID }}/secrets/nmsample-stage-cloud-sql-pw/versions/latest\"" >> app.yaml
+
+        - name: Deploy to Google Cloud
+          run: |
+            gcloud app deploy app.yaml --quiet --project ${{ secrets.GCP_PROJECT_ID }}
+
+        - name: Remove app.yaml
+          run: |
+            rm app.yaml
+
+        # Use PR author's username as git user name
+        - name: Set up git user
+          run: |
+            git config --global user.name "${{ github.actor }}"
+            git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+        # ":" are not alloed in git tags, so replace with "-"
+        - name: Tag commit
+          run: |
+            git tag -a "staging-deploy-$(date -u +%Y-%m-%d)T$(date -u +%H-%M-%S%z)" -m "staging gcloud deployment: $(date -u +%Y-%m-%d)T$(date -u +%H:%M:%S%z)"
+            git push origin --tags

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -41,7 +41,7 @@ jobs:
 
         - name: Deploy to Google Cloud
           run: |
-            gcloud app deploy app.yaml --quiet --project ${{ secrets.GCP_PROJECT_ID }}
+            gcloud app deploy app.yaml --quiet --project ${{ secrets.GCP_PROJECT_ID }} --no-promote
 
         - name: Remove app.yaml
           run: |

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -25,7 +25,7 @@ jobs:
         - name: Create app.yaml
           run: |
             echo "service: nmsamplelocations" > app.yaml
-            echo "runtime: python310" >> app.yaml
+            echo "runtime: python313" >> app.yaml
             echo "entrypoint: gunicorn -w 4 -k uvicorn.workers.UvicornWorker main:app" >> app.yaml
             echo "instance_class: F4" >> app.yaml
             echo "" >> app.yaml


### PR DESCRIPTION
This PR:
 - Adds a staging_deploy.yml file in the Github actions workflow file
 - Triggers app engine deploys from push to the pre-production branch
 - Uses a new repo environment called "staging" for running the action and storing github secrets
 - app secrets are stored in Google Secret Manager and handled by App Engine at build via app.yaml through the app engine service account - this is something new to try and we will see how it works.

 - We should look into Cloud Build triggers in case we'd like to transition to using Cloud Build instead of Github Actions.