### PR TITLE
BDMS-20: use uv export

### DIFF
--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -21,13 +21,9 @@ jobs:
           with:
             version: "latest"
 
-        - name: Sync environment
-          run: |
-            uv sync
-
         - name: Generate requirements.txt
           run: |
-            uv pip freeze > requirements.txt
+            uv export -o requirements.txt
 
         - name: Authenticate to Google Cloud
           uses: 'google-github-actions/auth@v2'

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -21,6 +21,10 @@ jobs:
           with:
             version: "latest"
 
+        - name: Sync environment
+          run: |
+            uv sync
+
         - name: Generate requirements.txt
           run: |
             uv pip freeze > requirements.txt


### PR DESCRIPTION
Instead of using pip freeze and uv sync which requires an environment to be materialized, uv export should just write the dependencies from pyproject.toml to a requirements.txt file.