### PR TITLE
fix: fixed init_lexicon

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -69,7 +69,11 @@ def init_lexicon():
                     term_dict["definition"],
                     term_dict["category"],
                 )
-            except DatabaseError:
+            except DatabaseError as e:
+                print(
+                    f"Failed to add term {term_dict['term']}: {term_dict['definition']} error: {e}"
+                )
+
                 session.rollback()
 
 

--- a/services/lexicon.py
+++ b/services/lexicon.py
@@ -25,39 +25,36 @@ def add_lexicon_term(
     Add a term to the lexicon with its definition and category.
 
     """
-    with session.no_autoflush:
-        if isinstance(category, str):
-            sql = select(Category).where(Category.name == category)
-            dbcategory = session.scalars(sql).one_or_none()
-            if dbcategory is None:
-                # Create a new category if it does not exist
-                dbcategory = Category(name=category)
-                session.add(dbcategory)
-                session.commit()
-                session.flush()
-        else:
-            dbcategory = session.get(Category, category)
+    if isinstance(category, str):
+        sql = select(Category).where(Category.name == category)
+        dbcategory = session.scalars(sql).one_or_none()
+        if dbcategory is None:
+            # Create a new category if it does not exist
+            dbcategory = Category(name=category)
+            session.add(dbcategory)
+            session.commit()
+            session.flush()
+    else:
+        dbcategory = session.get(Category, category)
 
-        # Check if the term already exists
-        sql = select(Lexicon).where(Lexicon.term == term)
-        existing_term = session.scalars(sql).one_or_none()
-        if existing_term is not None:
-            return existing_term
+    # Check if the term already exists
+    sql = select(Lexicon).where(Lexicon.term == term)
+    dbterm = session.scalars(sql).one_or_none()
+    if dbterm is None:
+        dbterm = Lexicon(term=term, definition=definition)
+        session.add(dbterm)
 
-        term = Lexicon(term=term, definition=definition)
-        session.add(term)
+    if dbcategory is not None:
+        link = TermCategoryAssociation()
 
-        if dbcategory is not None:
-            link = TermCategoryAssociation()
+        link.category = dbcategory
+        link.term = dbterm
 
-            link.category = dbcategory
-            link.term = term
+        session.add(link)
 
-            session.add(link)
+    session.commit()
 
-        session.commit()
-
-        return term
+    return dbterm
 
 
 # ============= EOF =============================================


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
This PR fixes initialization of the lexicon from the lexicon.json. There was an issue when adding a term to multiple categories. 

### **How**
_Implementation summary - the following was changed / added / removed:_
- fixed `init_lexicon` to either add or use and existing term. If the term exists it still will try to add to a category

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
N/A
