### PR TITLE
NO TICKET: organize API endpoints and documentation

### DIFF
--- a/api/lexicon.py
+++ b/api/lexicon.py
@@ -33,6 +33,7 @@ from services.lexicon import add_lexicon_term
 
 router = APIRouter(
     prefix="/lexicon",
+    tags=["lexicon"],
 )
 
 

--- a/api/sample.py
+++ b/api/sample.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 # ===============================================================================
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
-from starlette.status import HTTP_201_CREATED, HTTP_404_NOT_FOUND
+from starlette.status import HTTP_201_CREATED
 
 from api.pagination import CustomPage
 from core.dependencies import session_dependency
@@ -30,6 +30,7 @@ from services.crud_helper import model_patcher
 
 router = APIRouter(
     prefix="/sample",
+    tags=["sample"],
 )
 
 

--- a/main.py
+++ b/main.py
@@ -34,29 +34,24 @@ from api.asset import router as asset_router
 from api.search import router as search_router
 from api.geospatial import router as geospatial_router
 
-
-app.include_router(contact_router)
-app.include_router(group_router)
-
-app.include_router(location_router)
-app.include_router(thing_router)
-app.include_router(sensor_router)
-# app.include_router(series_router)
-app.include_router(sample_router)
-app.include_router(observation_router)
-app.include_router(search_router)
-app.include_router(geospatial_router)
-
-# app.include_router(form_router)
-app.include_router(lexicon_router)
-app.include_router(geothermal_router)
-app.include_router(geochronology_router)
-app.include_router(publication_router)
-app.include_router(author_router)
 app.include_router(asset_router)
+app.include_router(author_router)
+app.include_router(contact_router)
+app.include_router(geochronology_router)
+app.include_router(geospatial_router)
+app.include_router(geothermal_router)
+app.include_router(group_router)
+app.include_router(lexicon_router)
+app.include_router(location_router)
+app.include_router(observation_router)
+app.include_router(publication_router)
+app.include_router(sample_router)
+app.include_router(sensor_router)
+app.include_router(search_router)
+app.include_router(thing_router)
 
-from admin.user import *
-from admin.base import *
+from admin.user import *  # noqa: F401, F403
+from admin.base import *  # noqa: F401, F403
 
 app.mount("/admin", admin_app)
 


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem / context:_
- To make the OpenAPI documentation easier to understand the routers should be in their own well-defined sections.
- It should also be easy to scroll through the documentation and find the router/collection of endpoints needed

### **How**
_Implementation summary - the following was changed / added / removed:_
- `lexicon` and `sample` were missing tags that have now been added
- Order the routers alphabetically for easier access
