### PR TITLE
NO TICKET: update all datetime fields to be timezone aware in the database and schemas

### DIFF
--- a/api/sample.py
+++ b/api/sample.py
@@ -60,7 +60,9 @@ def database_error_handler(
 
 # ============= Post =============================================
 @router.post("", status_code=HTTP_201_CREATED)
-def add_sample(sample_data: CreateSample, session: session_dependency):
+def add_sample(
+    sample_data: CreateSample, session: session_dependency
+) -> SampleResponse:
     """
     Endpoint to add a sample.
     """

--- a/db/base.py
+++ b/db/base.py
@@ -57,7 +57,11 @@ class ReleaseMixin:
 class AuditMixin:
     @declared_attr
     def created_at(self):
-        return Column(DateTime, nullable=False, server_default=func.now())
+        return Column(
+            DateTime(timezone=True),
+            nullable=False,
+            server_default=func.timezone("UTC", func.now()),
+        )
 
 
 class AutoBaseMixin(AuditMixin):

--- a/db/location.py
+++ b/db/location.py
@@ -19,7 +19,6 @@ from sqlalchemy import (
     Integer,
     String,
     ForeignKey,
-    Boolean,
     DateTime,
     func,
     Text,
@@ -56,8 +55,13 @@ class LocationThingAssociation(Base, AutoBaseMixin):
         Integer, ForeignKey("thing.id", ondelete="CASCADE"), primary_key=True
     )
 
-    effective_start = Column(DateTime, nullable=False, server_default=func.now())
-    effective_end = Column(DateTime, nullable=True)
+    # REFACTOR TODO: when refactoring/updating location/thing schemas and tests, ensure timezone is UTC
+    effective_start = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.timezone("UTC", func.now()),
+    )
+    effective_end = Column(DateTime(timezone=True), nullable=True)
 
     location = relationship("Location")
     thing = relationship("Thing")

--- a/db/observation.py
+++ b/db/observation.py
@@ -16,13 +16,11 @@
 from sqlalchemy import (
     ForeignKey,
     Integer,
-    DateTime,
     TIMESTAMP,
     PrimaryKeyConstraint,
-    ForeignKeyConstraint,
     Float,
 )
-from sqlalchemy.orm import declared_attr, mapped_column, relationship
+from sqlalchemy.orm import mapped_column, relationship
 
 from db.base import Base, AuditMixin, ReleaseMixin, lexicon_term
 
@@ -57,7 +55,7 @@ class Observation(Base, AuditMixin, ReleaseMixin):
     )
 
     observation_timestamp = mapped_column(
-        TIMESTAMP, nullable=False, doc="Timestamp of the observation"
+        TIMESTAMP(timezone=True), nullable=False, doc="Timestamp of the observation"
     )
     observed_property = lexicon_term()
 

--- a/db/sample.py
+++ b/db/sample.py
@@ -48,7 +48,9 @@ class Sample(Base, AutoBaseMixin, ReleaseMixin):
 
     # Sample Attributes
     sample_date: Mapped[datetime.datetime] = mapped_column(
-        DateTime, nullable=False, comment="Date and time of sample collection."
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Date and time of sample collection.",
     )
     # REFACTOR TODO: update with enum/restricted values
     sample_matrix: Mapped[Optional[str]] = mapped_column(

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
-from datetime import datetime
-
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, AwareDatetime
 
 
 class ORMBaseModel(BaseModel):
     id: int  # every ORM model should have an id field
-    created_at: datetime
+    created_at: AwareDatetime
     model_config = ConfigDict(
         from_attributes=True,
         populate_by_name=True,

--- a/schemas_v2/asset.py
+++ b/schemas_v2/asset.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
-from datetime import datetime
-
-from pydantic import BaseModel
+from pydantic import BaseModel, AwareDatetime
 
 
 class BaseAsset(BaseModel):
@@ -42,7 +40,7 @@ class AssetResponse(BaseAsset):
     # storage_path: str
     # mime_type: str
     # size: int
-    created_at: datetime
+    created_at: AwareDatetime
     storage_service: str
 
 

--- a/schemas_v2/contact.py
+++ b/schemas_v2/contact.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
-from datetime import datetime
 from typing import Optional, List
 
 import phonenumbers
 from email_validator import validate_email, EmailNotValidError
 from phonenumbers import NumberParseException
-from pydantic import field_validator, BaseModel
+from pydantic import field_validator, BaseModel, AwareDatetime
 
 from schemas import ORMBaseModel
 from schemas_v2.thing import ThingResponse
@@ -193,7 +192,7 @@ class ContactResponse(ORMBaseModel):
     id: int
     name: str
     role: str
-    created_at: datetime
+    created_at: AwareDatetime
     emails: List[EmailResponse] = []
     phones: List[PhoneResponse] = []
     addresses: List[AddressResponse] = []

--- a/schemas_v2/observation.py
+++ b/schemas_v2/observation.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
-from pydantic import BaseModel, AwareDatetime, PastDatetime
+from datetime import timezone
+from pydantic import BaseModel, AwareDatetime, PastDatetime, field_validator
 from typing import Annotated
 
 
@@ -22,8 +23,29 @@ from typing import Annotated
 #     temperature: float
 
 
+# -------- VALIDATE -------
+
+
+class ValidateObservation(BaseModel):
+
+    @field_validator("observation_timestamp", check_fields=False)
+    def convert_observation_timestamp_to_utc(
+        observation_timestamp: AwareDatetime,
+    ) -> AwareDatetime:
+        """
+        Convert observation_timestamp to UTC timezone if it's not already. This runs after
+        the Annotated validator PastDatetime() is run.
+        """
+        if (
+            observation_timestamp is not None
+            and observation_timestamp.tzinfo != timezone.utc
+        ):
+            return observation_timestamp.astimezone(timezone.utc)
+        return observation_timestamp
+
+
 # -------- CREATE ----------
-class CreateBaseObservation(BaseModel):
+class CreateBaseObservation(ValidateObservation):
     observation_timestamp: Annotated[AwareDatetime, PastDatetime()]
     sample_id: int
     sensor_id: int

--- a/schemas_v2/observation.py
+++ b/schemas_v2/observation.py
@@ -13,9 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
-from datetime import datetime
-
-from pydantic import BaseModel
+from pydantic import BaseModel, AwareDatetime, PastDatetime
+from typing import Annotated
 
 
 # class GeothermalMixin:
@@ -25,7 +24,7 @@ from pydantic import BaseModel
 
 # -------- CREATE ----------
 class CreateBaseObservation(BaseModel):
-    observation_timestamp: datetime
+    observation_timestamp: Annotated[AwareDatetime, PastDatetime()]
     sample_id: int
     sensor_id: int
     observed_property: str
@@ -61,9 +60,9 @@ class BaseObservationResponse(BaseModel):
     id: int
     sample_id: int
     sensor_id: int
-    observation_timestamp: datetime
+    observation_timestamp: AwareDatetime
     observed_property: str
-    created_at: datetime
+    created_at: AwareDatetime
     release_status: str
 
 

--- a/schemas_v2/sample.py
+++ b/schemas_v2/sample.py
@@ -13,8 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
-from datetime import datetime, timezone
-from pydantic import BaseModel, field_validator, model_validator
+from datetime import timezone
+from pydantic import (
+    BaseModel,
+    field_validator,
+    model_validator,
+    AwareDatetime,
+    PastDatetime,
+)
+from typing import Annotated
 from typing_extensions import Self
 
 
@@ -29,16 +36,6 @@ class ValidateSample(BaseModel):
     """
     Validator for Sample data for Create and Update schemas.
     """
-
-    @field_validator("sample_date", check_fields=False)
-    def validate_sample_date(cls, sample_date: datetime | None) -> datetime | None:
-        """
-        Validate that the sample_date is not in the future.
-        """
-        if sample_date is not None:
-            if sample_date > datetime.now(tz=timezone.utc):
-                raise ValueError(f"Sample date {sample_date} cannot be in the future.")
-        return sample_date
 
     # # REFACTOR TODO: is below ground negative or positive? the combine this with validate_sample_bottom defined below
     # @field_validator("sample_bottom", check_fields=False)
@@ -73,13 +70,23 @@ class ValidateSample(BaseModel):
             )
         return self
 
+    @field_validator("sample_date", check_fields=False)
+    def convert_sample_date_to_utc(sample_date: AwareDatetime) -> AwareDatetime:
+        """
+        Convert sample_date to UTC timezone if it's not already. This runs after
+        the Annotated validator PastDatetime() is run.
+        """
+        if sample_date is not None and sample_date.tzinfo != timezone.utc:
+            return sample_date.astimezone(timezone.utc)
+        return sample_date
+
 
 # -------- CREATE ----------
 class CreateSample(ValidateSample):
     thing_id: int
     sample_type: str
     field_sample_id: str
-    sample_date: datetime
+    sample_date: Annotated[AwareDatetime, PastDatetime()]
     release_status: str
     sampler_name: str  # REFACTOR TODO: update with enum/restricted values
     qc_sample: str = "Original"
@@ -111,7 +118,7 @@ class UpdateSample(ValidateSample):
     thing_id: int = None  # REFACTOR TODO: should users be able to change this?
     sample_type: str = None
     field_sample_id: str = None
-    sample_date: datetime = None
+    sample_date: Annotated[AwareDatetime, PastDatetime()] = None
     release_status: str = None
     sampler_name: str = None  # REFACTOR TODO: update with enum/restricted values
     qc_sample: str = None
@@ -138,7 +145,7 @@ class SampleResponse(BaseModel):
     thing_id: int
     sample_type: str
     field_sample_id: str
-    sample_date: datetime
+    sample_date: AwareDatetime
     release_status: str
     sampler_name: str
     qc_sample: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def sensor():
 def sample(thing, sensor):
     with session_ctx() as session:
         sample = Sample(
-            sample_date="2025-01-01T00:00:00",
+            sample_date="2025-01-01T00:00:00Z",
             thing_id=thing.id,
             sample_type="groundwater",
             sampler_name="Test Sampler",

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -51,14 +51,6 @@ def second_sample(thing, sensor):
 # ============== Custom validators =================================================
 
 
-def test_validate_sample_date():
-    invalid_sample_date = "3500-01-01T00:00:00Z"
-    try:
-        invalid_sample = ValidateSample(sample_date=invalid_sample_date)
-    except ValueError as e:
-        assert str(e) == f"Sample date {invalid_sample_date} is not valid."
-
-
 def test_validate_sample_top_and_bottom():
     for i in range(2):
         sample_top = 10.0 if i == 0 else None
@@ -103,7 +95,7 @@ def test_add_sample(thing, sensor):
     assert data["thing_id"] == payload["thing_id"]
     assert data["sample_type"] == payload["sample_type"]
     assert data["field_sample_id"] == payload["field_sample_id"]
-    assert data["sample_date"] == payload["sample_date"][:-1]
+    assert data["sample_date"] == payload["sample_date"]
     assert data["release_status"] == payload["release_status"]
     assert data["sampler_name"] == payload["sampler_name"]
     assert data["qc_sample"] == payload["qc_sample"]
@@ -200,7 +192,7 @@ def test_patch_sample(sample):
 
     assert data["id"] == sample.id
     assert data["sampler_name"] == new_sampler_name
-    assert data["sample_date"] == new_sample_date[:-1]
+    assert data["sample_date"] == new_sample_date
     assert data["sample_method"] == new_sample_method
 
     # rollback after updating the sample


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem / context:_
- In the 2025-08-07 WDI Dev Team Rendezvous we decided that all datetime records will be stored in UTC. The frontend will convert datetimes to the appropriate time zone(s) for display (probably MT)

### **How**
_Implementation summary - the following was changed / added / removed:_
- For the database models...
  - set all `DateTime` columns to `DateTime(timezone=True)`
  - set all `TIMESTAMP` columns to `TIMESTAMP(timezone=True)`
  - for all columns where a server_default may be called I changed `func.now()` to `func.timezone("UTC", func.now()` to ensure that the time zone is UTC. It defaults to the time zone of the database for `func.now()` so this change ensures the stored time zone is UTC if that is not how it is set in the db.
- For the Pydantic schemas...
  - used `pydantic.AwareDatetime` instead of `datetime.datetime` to require time zone aware fields to be passed and returned
  - ensured that any user-defined datetime fields must not be in the future by using Pydantic's `Annotated` field validations
  - converted user-defined datetime fields to UTC if not already in UTC

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- since all datetime field responses are UTC this uses the `Z` notation
- did I miss any models or fields?
  - the sensor model has yet to be refactored, so that was not updated
- the time zone must be set by the application layer. Because something(s) may slip through the cracks, should we convert `AwareDatetime` responses to UTC? Just to be extra safe.