### PR TITLE
NO TICKET: Cascade lexicon term updates

### DIFF
--- a/db/base.py
+++ b/db/base.py
@@ -41,9 +41,14 @@ make_searchable(Base.metadata)
 
 
 def lexicon_term(**kw):
-    return mapped_column(String(100), ForeignKey("lexicon_term.term",
-                                                 onupdate='CASCADE',
-                                                 ), **kw)
+    return mapped_column(
+        String(100),
+        ForeignKey(
+            "lexicon_term.term",
+            onupdate="CASCADE",
+        ),
+        **kw,
+    )
 
 
 def pascal_to_snake(name):

--- a/db/base.py
+++ b/db/base.py
@@ -41,7 +41,9 @@ make_searchable(Base.metadata)
 
 
 def lexicon_term(**kw):
-    return mapped_column(String(100), ForeignKey("lexicon_term.term"), **kw)
+    return mapped_column(String(100), ForeignKey("lexicon_term.term",
+                                                 onupdate='CASCADE',
+                                                 ), **kw)
 
 
 def pascal_to_snake(name):

--- a/db/base.py
+++ b/db/base.py
@@ -40,12 +40,16 @@ class Base(DeclarativeBase):
 make_searchable(Base.metadata)
 
 
-def lexicon_term(**kw):
+def lexicon_term(foreignkeykw=None, **kw):
+
+    fkw = foreignkeykw if foreignkeykw else {}
+
     return mapped_column(
         String(100),
         ForeignKey(
             "lexicon_term.term",
             onupdate="CASCADE",
+            **fkw
         ),
         **kw,
     )

--- a/db/base.py
+++ b/db/base.py
@@ -46,11 +46,7 @@ def lexicon_term(foreignkeykw=None, **kw):
 
     return mapped_column(
         String(100),
-        ForeignKey(
-            "lexicon_term.term",
-            onupdate="CASCADE",
-            **fkw
-        ),
+        ForeignKey("lexicon_term.term", onupdate="CASCADE", **fkw),
         **kw,
     )
 

--- a/db/lexicon.py
+++ b/db/lexicon.py
@@ -60,10 +60,7 @@ class TermCategoryAssociation(Base, AutoBaseMixin):
 
     __tablename__ = "lexicon_term_category_association"
 
-    # lexicon_term = mapped_column(
-    #     String(100), ForeignKey("lexicon_term.term", ondelete="CASCADE"), nullable=False
-    # )
-    lexicon_term = lexicon_term()
+    lexicon_term = lexicon_term(foreignkeykw={'ondelete':"CASCADE"})
     category_name = mapped_column(
         String(255),
         ForeignKey("lexicon_category.name", ondelete="CASCADE"),

--- a/db/lexicon.py
+++ b/db/lexicon.py
@@ -60,7 +60,7 @@ class TermCategoryAssociation(Base, AutoBaseMixin):
 
     __tablename__ = "lexicon_term_category_association"
 
-    lexicon_term = lexicon_term(foreignkeykw={'ondelete':"CASCADE"})
+    lexicon_term = lexicon_term(foreignkeykw={"ondelete": "CASCADE"})
     category_name = mapped_column(
         String(255),
         ForeignKey("lexicon_category.name", ondelete="CASCADE"),

--- a/db/lexicon.py
+++ b/db/lexicon.py
@@ -16,7 +16,7 @@
 from sqlalchemy import String, Integer, ForeignKey
 from sqlalchemy.orm import mapped_column, relationship
 
-from db.base import AutoBaseMixin, Base
+from db.base import AutoBaseMixin, Base, lexicon_term
 
 
 class Lexicon(Base, AutoBaseMixin):
@@ -60,9 +60,10 @@ class TermCategoryAssociation(Base, AutoBaseMixin):
 
     __tablename__ = "lexicon_term_category_association"
 
-    lexicon_term = mapped_column(
-        String(100), ForeignKey("lexicon_term.term", ondelete="CASCADE"), nullable=False
-    )
+    # lexicon_term = mapped_column(
+    #     String(100), ForeignKey("lexicon_term.term", ondelete="CASCADE"), nullable=False
+    # )
+    lexicon_term = lexicon_term()
     category_name = mapped_column(
         String(255),
         ForeignKey("lexicon_category.name", ondelete="CASCADE"),
@@ -82,13 +83,9 @@ class LexiconTriple(Base, AutoBaseMixin):
     This can be used to represent relationships between terms.
     """
 
-    subject = mapped_column(
-        String(100), ForeignKey("lexicon_term.term", ondelete="CASCADE"), nullable=False
-    )
+    subject = lexicon_term(nullable=False)
     predicate = mapped_column(String(100), nullable=False)
-    object_ = mapped_column(
-        String(100), ForeignKey("lexicon_term.term", ondelete="CASCADE"), nullable=False
-    )
+    object_ = lexicon_term(nullable=False)
 
     subject_term = relationship("Lexicon", foreign_keys=[subject])
     object_term = relationship("Lexicon", foreign_keys=[object_])


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- Since the lexicon term is used as the foreign key changes to it need to be cascaded 

### **How**
_Implementation summary - the following was changed / added / removed:_
- added `onupdate='CASCADE'` to lexicon_term function

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- use the `lexicon_term` convenience function in all models that use the lexicon
