### PR TITLE
HOT FIX:  Staging deploy

### DIFF
--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -36,7 +36,7 @@ jobs:
         # Uses Google Cloud Secret Manager to store secret credentials
         - name: Create app.yaml
           run: |
-            echo "service: nmsamplelocations" > app.yaml
+            echo "service: ocotillo-api" > app.yaml
             echo "runtime: python313" >> app.yaml
             echo "entrypoint: gunicorn -w 4 -k uvicorn.workers.UvicornWorker main:app" >> app.yaml
             echo "instance_class: F4" >> app.yaml
@@ -63,10 +63,12 @@ jobs:
         # Clean up old versions - delete only the oldest version, one created and one destroyed
         - name: Clean up oldest version
           run: |
-            OLDEST_VERSION=$(gcloud app versions list --service=nmsamplelocations --project=${{ secrets.GCP_PROJECT_ID }} --format="value(id)" --sort-by="version.createTime" | head -n 1)
+            OLDEST_VERSION=$(gcloud app versions list --service=ocotillo-api --project=${{ secrets.GCP_PROJECT_ID }} 
+            --format="value(id)" --sort-by="version.createTime" | head -n 1)
             if [ ! -z "$OLDEST_VERSION" ]; then
               echo "Deleting oldest version: $OLDEST_VERSION"
-              gcloud app versions delete $OLDEST_VERSION --service=nmsamplelocations --project=${{ secrets.GCP_PROJECT_ID }} --quiet
+              gcloud app versions delete $OLDEST_VERSION --service=ocotillo-api --project=${{ secrets.GCP_PROJECT_ID }} 
+            --quiet
               echo "Deleted oldest version: $OLDEST_VERSION"
             else
               echo "No versions to delete"

--- a/api/asset.py
+++ b/api/asset.py
@@ -108,7 +108,8 @@ async def list_assets(
 
     def transformer(records: list[Asset]):
         if thing_id is not None:
-            records = [add_signed_url(ai, get_storage_bucket()) for ai in records]
+            bucket = get_storage_bucket()
+            records = [add_signed_url(ai, bucket) for ai in records]
 
         return records
 


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- The staging deploy workflow was pushing to the `nmsamplelocations` service. The service has been renamed to `ocotillo-api`
- transformer is calling `get_storage_bucket` for every asset

### **How**
_Implementation summary - the following was changed / added / removed:_
- Updated staging deploy workflow file
- get bucket outside of list comprehension

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Use bullet points here
