### PR TITLE
location_model_update_kas

### DIFF
--- a/db/location.py
+++ b/db/location.py
@@ -26,17 +26,17 @@ from sqlalchemy import (
     DateTime,
     func,
     Text,
+    UUID,
 )
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 from sqlalchemy.ext.associationproxy import association_proxy, AssociationProxy
+
+from db import Thing
 from db.base import Base, AutoBaseMixin, ReleaseMixin
 from db.lexicon import lexicon_term
 
 
 class Location(Base, AutoBaseMixin, ReleaseMixin):
-    # name = Column(String(100), nullable=True)
-    # description = Column(String(255), nullable=True)
-    # visible = Column(Boolean, default=False, nullable=False)
     __versioned__ = {}
 
     nma_pk_location: Mapped[UUID] = mapped_column(

--- a/db/location.py
+++ b/db/location.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
+import datetime
+
 from geoalchemy2 import Geometry, WKBElement
 from geoalchemy2.shape import to_shape
 
@@ -36,15 +38,15 @@ class Location(Base, AutoBaseMixin, ReleaseMixin):
     # visible = Column(Boolean, default=False, nullable=False)
     __versioned__ = {}
 
-    name = mapped_column(String(255), nullable=True)
-    notes = mapped_column(Text, nullable=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=True)
+    notes: Mapped[str] = mapped_column(Text, nullable=True)
     point: Mapped[WKBElement] = mapped_column(
         Geometry(geometry_type="POINTZ", srid=4326, spatial_index=True)
     )
 
-    state = lexicon_term(nullable=True)
-    county = lexicon_term(nullable=True)
-    quad_name = mapped_column(String(100), nullable=True)
+    state: Mapped[str] = lexicon_term(nullable=True, default = "New Mexico")
+    county: Mapped[str] = lexicon_term(nullable=True)
+    quad_name: Mapped[str] = mapped_column(String(100), nullable=True)
 
     @property
     def latlon(self):
@@ -53,20 +55,25 @@ class Location(Base, AutoBaseMixin, ReleaseMixin):
 
 
 class LocationThingAssociation(Base, AutoBaseMixin):
-    location_id = Column(
-        Integer, ForeignKey("location.id", ondelete="CASCADE"), primary_key=True
+    location_id: Mapped[int] = mapped_column(
+        ForeignKey("location.id", ondelete="CASCADE"),
+        primary_key=True
     )
-    thing_id = Column(
-        Integer, ForeignKey("thing.id", ondelete="CASCADE"), primary_key=True
+    thing_id: Mapped[int] = mapped_column(
+        ForeignKey("thing.id", ondelete="CASCADE"),
+        primary_key=True
     )
 
     # REFACTOR TODO: when refactoring/updating location/thing schemas and tests, ensure timezone is UTC
-    effective_start = Column(
+    effective_start: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         server_default=func.timezone("UTC", func.now()),
     )
-    effective_end = Column(DateTime(timezone=True), nullable=True)
+    effective_end: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True
+    )
 
     location = relationship("Location")
     thing = relationship("Thing")

--- a/db/location.py
+++ b/db/location.py
@@ -28,6 +28,7 @@ from sqlalchemy import (
     Text,
 )
 from sqlalchemy.orm import relationship, Mapped, mapped_column
+from sqlalchemy.ext.associationproxy import association_proxy, AssociationProxy
 from db.base import Base, AutoBaseMixin, ReleaseMixin
 from db.lexicon import lexicon_term
 
@@ -47,6 +48,15 @@ class Location(Base, AutoBaseMixin, ReleaseMixin):
     state: Mapped[str] = lexicon_term(nullable=True, default = "New Mexico")
     county: Mapped[str] = lexicon_term(nullable=True)
     quad_name: Mapped[str] = mapped_column(String(100), nullable=True)
+
+    # --- Relationship Definitions ---
+    thing_associations: Mapped[list["LocationThingAssociation"]] = relationship(
+        back_populates="location",
+        cascade="all, delete-orphan"
+    )
+
+    # --- Proxy Definitions ---
+    things: AssociationProxy[list["Thing"]] = association_proxy("thing_associations", "thing")
 
     @property
     def latlon(self):
@@ -75,8 +85,9 @@ class LocationThingAssociation(Base, AutoBaseMixin):
         nullable=True
     )
 
-    location = relationship("Location")
-    thing = relationship("Thing")
+    # --- Relationship Definitions ---
+    location: Mapped["Location"] = relationship(back_populates= "thing_associations")
+    thing: Mapped["Thing"] = relationship(back_populates = "location_associations")
 
 
 # ============= EOF =============================================

--- a/db/location.py
+++ b/db/location.py
@@ -18,6 +18,8 @@ import datetime
 from geoalchemy2 import Geometry, WKBElement
 from geoalchemy2.shape import to_shape
 
+from uuid import UUID
+
 from sqlalchemy import (
     Column,
     Integer,
@@ -26,7 +28,6 @@ from sqlalchemy import (
     DateTime,
     func,
     Text,
-    UUID,
 )
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 from sqlalchemy.ext.associationproxy import association_proxy, AssociationProxy

--- a/db/location.py
+++ b/db/location.py
@@ -39,8 +39,9 @@ class Location(Base, AutoBaseMixin, ReleaseMixin):
     # visible = Column(Boolean, default=False, nullable=False)
     __versioned__ = {}
 
+    nma_pk_location: Mapped[UUID] = mapped_column(String(36), nullable=True, unique=True)
+    description: Mapped[str] = mapped_column
     name: Mapped[str] = mapped_column(String(255), nullable=True)
-    notes: Mapped[str] = mapped_column(Text, nullable=True)
     point: Mapped[WKBElement] = mapped_column(
         Geometry(geometry_type="POINTZ", srid=4326, spatial_index=True)
     )
@@ -48,6 +49,8 @@ class Location(Base, AutoBaseMixin, ReleaseMixin):
     state: Mapped[str] = lexicon_term(nullable=True, default = "New Mexico")
     county: Mapped[str] = lexicon_term(nullable=True)
     quad_name: Mapped[str] = mapped_column(String(100), nullable=True)
+    notes: Mapped[str] = mapped_column(Text, nullable=True)
+    nma_notes_location: Mapped[str] = mapped_column(Text, nullable=True)
 
     # --- Relationship Definitions ---
     thing_associations: Mapped[list["LocationThingAssociation"]] = relationship(

--- a/db/location.py
+++ b/db/location.py
@@ -39,14 +39,16 @@ class Location(Base, AutoBaseMixin, ReleaseMixin):
     # visible = Column(Boolean, default=False, nullable=False)
     __versioned__ = {}
 
-    nma_pk_location: Mapped[UUID] = mapped_column(String(36), nullable=True, unique=True)
+    nma_pk_location: Mapped[UUID] = mapped_column(
+        String(36), nullable=True, unique=True
+    )
     description: Mapped[str] = mapped_column
     name: Mapped[str] = mapped_column(String(255), nullable=True)
     point: Mapped[WKBElement] = mapped_column(
         Geometry(geometry_type="POINTZ", srid=4326, spatial_index=True)
     )
 
-    state: Mapped[str] = lexicon_term(nullable=True, default = "New Mexico")
+    state: Mapped[str] = lexicon_term(nullable=True, default="New Mexico")
     county: Mapped[str] = lexicon_term(nullable=True)
     quad_name: Mapped[str] = mapped_column(String(100), nullable=True)
     notes: Mapped[str] = mapped_column(Text, nullable=True)
@@ -54,12 +56,13 @@ class Location(Base, AutoBaseMixin, ReleaseMixin):
 
     # --- Relationship Definitions ---
     thing_associations: Mapped[list["LocationThingAssociation"]] = relationship(
-        back_populates="location",
-        cascade="all, delete-orphan"
+        back_populates="location", cascade="all, delete-orphan"
     )
 
     # --- Proxy Definitions ---
-    things: AssociationProxy[list["Thing"]] = association_proxy("thing_associations", "thing")
+    things: AssociationProxy[list["Thing"]] = association_proxy(
+        "thing_associations", "thing"
+    )
 
     @property
     def latlon(self):
@@ -69,12 +72,10 @@ class Location(Base, AutoBaseMixin, ReleaseMixin):
 
 class LocationThingAssociation(Base, AutoBaseMixin):
     location_id: Mapped[int] = mapped_column(
-        ForeignKey("location.id", ondelete="CASCADE"),
-        primary_key=True
+        ForeignKey("location.id", ondelete="CASCADE"), primary_key=True
     )
     thing_id: Mapped[int] = mapped_column(
-        ForeignKey("thing.id", ondelete="CASCADE"),
-        primary_key=True
+        ForeignKey("thing.id", ondelete="CASCADE"), primary_key=True
     )
 
     # REFACTOR TODO: when refactoring/updating location/thing schemas and tests, ensure timezone is UTC
@@ -84,13 +85,12 @@ class LocationThingAssociation(Base, AutoBaseMixin):
         server_default=func.timezone("UTC", func.now()),
     )
     effective_end: Mapped[datetime.datetime] = mapped_column(
-        DateTime(timezone=True),
-        nullable=True
+        DateTime(timezone=True), nullable=True
     )
 
     # --- Relationship Definitions ---
-    location: Mapped["Location"] = relationship(back_populates= "thing_associations")
-    thing: Mapped["Thing"] = relationship(back_populates = "location_associations")
+    location: Mapped["Location"] = relationship(back_populates="thing_associations")
+    thing: Mapped["Thing"] = relationship(back_populates="location_associations")
 
 
 # ============= EOF =============================================

--- a/db/location.py
+++ b/db/location.py
@@ -32,7 +32,6 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 from sqlalchemy.ext.associationproxy import association_proxy, AssociationProxy
 
-from db import Thing
 from db.base import Base, AutoBaseMixin, ReleaseMixin
 from db.lexicon import lexicon_term
 


### PR DESCRIPTION
<!--
BDMS-85: Update the Location model
-->
### **Why**
_This PR addresses the following problem / context:_
- Missing fields needed to be added to the Ocotillo models
- Models syntax should conform to the latest type-hinting/mapping styles for SQL Alchemy 2.0
- Association proxies should be added. They help manage many-to-many relationships and allow the user to interact with primary model objects and not the intermediary join model. 

### **How**
_Implementation summary - the following was changed / added / removed:_
- Updated:
	- The Location model field syntax to conform to the latest syntax style for SQLAlchemy 2.0
	- The Location model relationship syntax to conform to the latest syntax style for SQLAlchemy 2.0
	- The relationships in the LocationThingAssociation model to reflect the use of proxies
- Added:
	- `thing_associations` relationship to the Location model
	- An association proxy to the Location model.
	- Imported the `association_proxy` function and `AssociationProxy` class so proxies can be implemented
	- (TD) The following fields: `nma_pk_location`, `nma_notes_location`

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- `schema` files were not updated. The only fields that were added were fields whose purpose is to preserve information from NMAquifer.
- `test` files have not been updated. I'm not sure if they need to be.

_Questions_
    - I think the Group model needs a relationship to the Location table. Thoughts?
    - In the `schemas\location.py` file, Should the `effective_start` and `effective_end` fields of the `LocationThingAssociation` be included in the UPDATE schema?
    - I noticed the `Thing` model uses the `overlaps` relationship attribute. Should this be used in the `Location` model, too?
    - I assigned the `nma_pk_location` field a `Mapped[UUID]` type attribute. Should  `nma_pk_tablename` fields be assigned `Mapped[str]` or `Mapped[UUID]` type attributes? I think NMAquifer stored primary keys as GUIDs.
