### PR TITLE
NO-TICKET: Internal and Public API specs

### DIFF
--- a/api/thing.py
+++ b/api/thing.py
@@ -25,6 +25,7 @@ from starlette.status import (
 )
 
 from api.pagination import CustomPage
+from core.app import public_route
 from core.dependencies import (
     session_dependency,
     amp_admin_dependency,
@@ -270,7 +271,7 @@ async def get_thing_id_links(
 
     return paginate(query=sql, conn=session)
 
-
+@public_route
 @router.get("/id-link/{link_id}", summary="Get thing links by link ID")
 async def get_thing_id_links(
     link_id: int,
@@ -282,6 +283,7 @@ async def get_thing_id_links(
     return simple_get_by_id(session, ThingIdLink, link_id)
 
 
+@public_route
 @router.get("", summary="Get all things", status_code=HTTP_200_OK)
 async def get_things(
     session: session_dependency,

--- a/api/thing.py
+++ b/api/thing.py
@@ -271,6 +271,7 @@ async def get_thing_id_links(
 
     return paginate(query=sql, conn=session)
 
+
 @public_route
 @router.get("/id-link/{link_id}", summary="Get thing links by link ID")
 async def get_thing_id_links(

--- a/core/app.py
+++ b/core/app.py
@@ -18,7 +18,10 @@ from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
 from fastapi import FastAPI
-from fastapi.openapi.docs import get_swagger_ui_html, get_swagger_ui_oauth2_redirect_html
+from fastapi.openapi.docs import (
+    get_swagger_ui_html,
+    get_swagger_ui_oauth2_redirect_html,
+)
 from fastapi.openapi.utils import get_openapi
 
 from .initializers import init_db, init_lexicon
@@ -42,6 +45,7 @@ app = FastAPI(
     version=settings.version,
     lifespan=lifespan,
 )
+
 
 # --- full OpenAPI schema ---
 def full_openapi():
@@ -74,7 +78,11 @@ def public_openapi():
             # Recover the actual route handler
 
             route = next(
-                (r for r in app.routes if r.path == path and method.upper() in r.methods),
+                (
+                    r
+                    for r in app.routes
+                    if r.path == path and method.upper() in r.methods
+                ),
                 None,
             )
             if not route:
@@ -97,7 +105,11 @@ def public_openapi():
     def collect_refs(obj):
         if isinstance(obj, dict):
             for k, v in obj.items():
-                if k == "$ref" and isinstance(v, str) and v.startswith("#/components/schemas/"):
+                if (
+                    k == "$ref"
+                    and isinstance(v, str)
+                    and v.startswith("#/components/schemas/")
+                ):
                     referenced.add(v.split("/")[-1])
                 else:
                     collect_refs(v)
@@ -124,7 +136,7 @@ def public_openapi():
 
         collect_refs(model)
         # Add only new schemas we haven’t visited yet
-        to_visit |= (referenced - visited)
+        to_visit |= referenced - visited
 
     # Step 3: Filter components.schemas to only referenced ones
     if "components" in schema and "schemas" in schema["components"]:
@@ -147,7 +159,7 @@ CLIENT_ID = os.environ.get("AUTHENTIK_CLIENT_ID")
 @app.get("/docs-auth", include_in_schema=False)
 async def custom_swagger_ui():
     return get_swagger_ui_html(
-        openapi_url='/openapi-auth.json',
+        openapi_url="/openapi-auth.json",
         title="Swagger UI",
         oauth2_redirect_url="/docs-auth/oauth2-redirect",
         init_oauth={
@@ -156,7 +168,8 @@ async def custom_swagger_ui():
         },
     )
 
-@app.get('/openapi-auth.json', include_in_schema=False)
+
+@app.get("/openapi-auth.json", include_in_schema=False)
 async def get_openapi_auth():
     return full_openapi()
 
@@ -170,4 +183,6 @@ def public_route(func):
     """Mark a route as public for OpenAPI filtering."""
     setattr(func, "_is_public", True)
     return func
+
+
 # ============= EOF =============================================

--- a/core/app.py
+++ b/core/app.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
+import os
 from contextlib import asynccontextmanager
-from http import HTTPStatus
 from typing import AsyncGenerator
 
 from fastapi import FastAPI
-from sqlalchemy import text
+from fastapi.openapi.docs import get_swagger_ui_html, get_swagger_ui_oauth2_redirect_html
+from fastapi.openapi.utils import get_openapi
 
-from .dependencies import session_dependency
 from .initializers import init_db, init_lexicon
 from .settings import settings
 
@@ -39,15 +39,135 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 app = FastAPI(
     title="Sample Location API",
     description="API for managing sample locations",
-    version="0.0.1",
+    version=settings.version,
     lifespan=lifespan,
 )
 
+# --- full OpenAPI schema ---
+def full_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+    schema = get_openapi(
+        title="Ocotillo API (Full)",
+        version=settings.version,
+        description="Full API schema (authorized users)",
+        routes=app.routes,
+    )
+    app.openapi_schema = schema
+    return app.openapi_schema
 
-@app.get("/_ah/warmup")
-async def warmup(session: session_dependency):
-    session.execute(text("SELECT 1"))
-    return HTTPStatus.OK
+
+# --- public OpenAPI schema ---
+def public_openapi():
+    schema = get_openapi(
+        title="Ocotillo API (Public)",
+        version="0.0.1",
+        description="Public API schema (anonymous users)",
+        routes=app.routes,
+    )
+
+    # Keep only operations where the endpoint function is marked public
+    new_paths = {}
+    for path, path_item in schema["paths"].items():
+        new_methods = {}
+        for method, operation in path_item.items():
+            # Recover the actual route handler
+
+            route = next(
+                (r for r in app.routes if r.path == path and method.upper() in r.methods),
+                None,
+            )
+            if not route:
+                continue
+
+            endpoint = getattr(route, "endpoint", None)
+            if getattr(endpoint, "_is_public", False):
+                # Strip security info for public docs
+                operation["security"] = []
+                new_methods[method] = operation
+
+        if new_methods:
+            new_paths[path] = new_methods
+
+    schema["paths"] = new_paths
+
+    # --- Collect all referenced schemas recursively ---
+    referenced = set()
+
+    def collect_refs(obj):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if k == "$ref" and isinstance(v, str) and v.startswith("#/components/schemas/"):
+                    referenced.add(v.split("/")[-1])
+                else:
+                    collect_refs(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                collect_refs(item)
+
+    # Step 1: Collect refs from paths
+    collect_refs(schema["paths"])
+
+    # Step 2: Recursively resolve inside components
+    visited = set()
+    to_visit = set(referenced)
+
+    while to_visit:
+        name = to_visit.pop()
+        if name in visited:
+            continue
+        visited.add(name)
+
+        model = schema.get("components", {}).get("schemas", {}).get(name)
+        if not model:
+            continue
+
+        collect_refs(model)
+        # Add only new schemas we haven’t visited yet
+        to_visit |= (referenced - visited)
+
+    # Step 3: Filter components.schemas to only referenced ones
+    if "components" in schema and "schemas" in schema["components"]:
+        schema["components"]["schemas"] = {
+            n: m for n, m in schema["components"]["schemas"].items() if n in referenced
+        }
+
+    # 4. Drop security schemes entirely for the public spec
+    if "components" in schema and "securitySchemes" in schema["components"]:
+        schema["components"].pop("securitySchemes", None)
+    return schema
 
 
+# set the public schema as the default
+app.openapi = public_openapi
+
+CLIENT_ID = os.environ.get("AUTHENTIK_CLIENT_ID")
+
+
+@app.get("/docs-auth", include_in_schema=False)
+async def custom_swagger_ui():
+    return get_swagger_ui_html(
+        openapi_url='/openapi-auth.json',
+        title="Swagger UI",
+        oauth2_redirect_url="/docs-auth/oauth2-redirect",
+        init_oauth={
+            "clientId": CLIENT_ID,
+            "usePkceWithAuthorizationCodeGrant": True,  # if you use PKCE
+        },
+    )
+
+@app.get('/openapi-auth.json', include_in_schema=False)
+async def get_openapi_auth():
+    return full_openapi()
+
+
+@app.get("/docs-auth/oauth2-redirect", include_in_schema=False)
+async def swagger_ui_redirect():
+    return get_swagger_ui_oauth2_redirect_html()
+
+
+def public_route(func):
+    """Mark a route as public for OpenAPI filtering."""
+    setattr(func, "_is_public", True)
+    return func
 # ============= EOF =============================================

--- a/core/settings.py
+++ b/core/settings.py
@@ -17,7 +17,7 @@ import os
 
 
 class Settings:
-
+    version = "0.0.1"
     def __init__(self):
         self.mode = os.getenv("MODE", "")  # Default mode
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -18,6 +18,7 @@ import os
 
 class Settings:
     version = "0.0.1"
+
     def __init__(self):
         self.mode = os.getenv("MODE", "")  # Default mode
 


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- Ocotillo API needs to serve both Ocotillo UI for internal users and a public api for anonymous external users.  The public api should be a subset of the total api. (maybe just a subset of the GET routes)

### **How**
_Implementation summary - the following was changed / added / removed:_
- Added `/docs-auth` and `/docs` routes.  
- `/docs` returns the public api spec `/docs-auth` returns the full api
- added the `public_route` decorator to indicated which routes should be included in the public openapi spec

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- I tried and struggled to make the `/docs-auth` only visible once the user has logged in, but went in circles with AI trying to accomplish a reasonable UX.  This should be revisited at a later date
