### PR TITLE
statushistory_model

### DIFF
--- a/db/base.py
+++ b/db/base.py
@@ -13,6 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
+"""
+db/base.py
+
+This file defines the foundational components for the SQLAlchemy models.
+It includes:
+1.  The declarative base class (`Base`) that all models will inherit from.
+2.  A helper function (`lexicon_term`) to create standardized foreign key columns
+    referencing the `lexicon_term` table.
+3. A helper function (`pascal_to_snake`) to convert class names from PascalCase to snake_case
+    for automatic table naming.
+4. Mixins for common functionality:
+    - `AutoBaseMixin`: Adds automatic table naming and an auto-incrementing primary key.
+    - `PropertiesMixin`: Adds a JSONB properties column for storing additional attributes.
+    - `ReleaseMixin`: Adds a release status column referencing the `lexicon_term` table.
+    - `AuditMixin`: Adds standard audit columns (created_at, created_by, updated_at, updated_by).
+5.  A simple `User` model for tracking user information in audit columns.
+6.  Polymorphic helper mixins (`HasStatusHistory`, `HasNotes`, `HasAttribution`, etc.)
+    which provide a clean, reusable way to add relationships to the polymorphic
+    metadata tables. Any model that can have a status history (like Thing or Location)
+    can simply inherit from the `HasStatusHistory` mixin.
+7.  An `AuditMixin` to add standard audit columns to tables.
+"""
+
 from sqlalchemy import (
     Column,
     DateTime,
@@ -20,8 +43,6 @@ from sqlalchemy import (
     Integer,
     JSON,
     String,
-    Boolean,
-    Text,
     ForeignKey,
 )
 from sqlalchemy.orm import DeclarativeBase, declared_attr, Mapped, mapped_column
@@ -41,6 +62,12 @@ make_searchable(Base.metadata)
 
 
 def lexicon_term(foreignkeykw=None, **kw):
+    """Create a SQLAlchemy mapped column for a self-referencing lexicon term.
+
+    This helper function simplifies the creation of a string column that also
+    acts as a foreign key to the 'term' column of the 'lexicon_term' table.
+    It standardizes the column type to String(100) and sets the onupdate
+    behavior to "CASCADE"."""
 
     fkw = foreignkeykw if foreignkeykw else {}
 
@@ -56,12 +83,16 @@ def pascal_to_snake(name):
 
 
 class ReleaseMixin:
+    """Mixin to add release status to a model."""
+
     @declared_attr
     def release_status(self):
         return lexicon_term(default="draft")
 
 
 class AuditMixin:
+    """Mixin to add standard audit columns to a model."""
+
     @declared_attr
     def created_at(self):
         return Column(
@@ -109,6 +140,8 @@ class AuditMixin:
 
 
 class AutoBaseMixin(AuditMixin):
+    """Mixin to add automatic table naming and an auto-incrementing primary key."""
+
     @declared_attr
     def __tablename__(self):
         return pascal_to_snake(self.__name__)
@@ -119,6 +152,8 @@ class AutoBaseMixin(AuditMixin):
 
 
 class PropertiesMixin:
+    """Mixin to add a JSONB properties column for storing additional attributes."""
+
     @declared_attr
     def properties(self):
         return Column(
@@ -130,6 +165,8 @@ class PropertiesMixin:
 
 
 class User(Base):
+    """Represents a user in the system."""
+
     __tablename__ = "user"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False)

--- a/db/base.py
+++ b/db/base.py
@@ -45,7 +45,13 @@ from sqlalchemy import (
     String,
     ForeignKey,
 )
-from sqlalchemy.orm import DeclarativeBase, declared_attr, Mapped, mapped_column
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    declared_attr,
+    Mapped,
+    mapped_column,
+    relationship,
+)
 from sqlalchemy_searchable import make_searchable
 from sqlalchemy_continuum import make_versioned
 import re
@@ -82,6 +88,7 @@ def pascal_to_snake(name):
     return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
 
 
+# ============= Common Mixins =============================================
 class ReleaseMixin:
     """Mixin to add release status to a model."""
 
@@ -161,6 +168,26 @@ class PropertiesMixin:
             JSON,
             nullable=True,
             comment="JSONB column for storing additional properties",
+        )
+
+
+# ============= Polymorphic Helper Mixins =============================================
+class HasStatusHistory:
+    """
+    Mixin for models that can have a status history (e.g., Thing, Location).
+    It automatically creates a polymorphic One-to-Many relationship to the
+    StatusHistory table.
+    """
+
+    @declared_attr
+    def status_history(self):
+        # One-to-Many polymorphic relationship
+        return relationship(
+            "StatusHistory",
+            primaryjoin=f"and_({self.__name__}.{self.__name__.lower()}_id==StatusHistory.statusable_id, "
+            f"StatusHistory.statusable_type=='{self.__name__}')",
+            cascade="all, delete-orphan",
+            lazy="selectin",
         )
 
 

--- a/db/base.py
+++ b/db/base.py
@@ -29,10 +29,10 @@ It includes:
     - `ReleaseMixin`: Adds a release status column referencing the `lexicon_term` table.
     - `AuditMixin`: Adds standard audit columns (created_at, created_by, updated_at, updated_by).
 5.  A simple `User` model for tracking user information in audit columns.
-6.  Polymorphic helper mixins (`HasStatusHistory`, `HasNotes`, `HasAttribution`, etc.)
+6.  Polymorphic helper mixins (`StatusHistoryMixin`, `NotesMixin`, `AttributionMixin`, etc.)
     which provide a clean, reusable way to add relationships to the polymorphic
     metadata tables. Any model that can have a status history (like Thing or Location)
-    can simply inherit from the `HasStatusHistory` mixin.
+    can simply inherit from the `StatusHistoryMixin` mixin.
 7.  An `AuditMixin` to add standard audit columns to tables.
 """
 
@@ -172,7 +172,7 @@ class PropertiesMixin:
 
 
 # ============= Polymorphic Helper Mixins =============================================
-class HasStatusHistory:
+class StatusHistoryMixin:
     """
     Mixin for models that can have a status history (e.g., Thing, Location).
     It automatically creates a polymorphic One-to-Many relationship to the

--- a/db/status_history.py
+++ b/db/status_history.py
@@ -1,0 +1,38 @@
+"""
+models/status_history.py
+
+This model defines the `StatusHistory` table, a central, polymorphic log for
+all time-variant operational statuses (e.g., Use Status, Access Status).
+
+**NOTE**: This is a polymorphic table. It does not define outgoing relationships
+itself. Instead, other tables (like Thing and Location) use the `HasStatusHistory`
+mixin to establish a One-to-Many relationship TO this table.
+"""
+
+import datetime
+
+from sqlalchemy import (
+    Integer,
+    String,
+    DateTime,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.base import Base, AutoBaseMixin, ReleaseMixin
+
+
+class StatusHistory(Base, AutoBaseMixin, ReleaseMixin):
+    status_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    status_value: Mapped[str] = mapped_column(String(50), nullable=False)
+    start_date: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    end_date: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    reason: Mapped[str] = mapped_column(Text, nullable=True)
+
+    # Polymorphic relationship columns
+    statusable_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    statusable_type: Mapped[str] = mapped_column(String(50), nullable=False)

--- a/db/status_history.py
+++ b/db/status_history.py
@@ -5,7 +5,7 @@ This model defines the `StatusHistory` table, a central, polymorphic log for
 all time-variant operational statuses (e.g., Use Status, Access Status).
 
 **NOTE**: This is a polymorphic table. It does not define outgoing relationships
-itself. Instead, other tables (like Thing and Location) use the `HasStatusHistory`
+itself. Instead, other tables (like Thing and Location) use the `StatusHistoryMixin`
 mixin to establish a One-to-Many relationship TO this table.
 """
 


### PR DESCRIPTION
<!--
- BDMS-117 Create StatusHistory table
-->
### **Why**
_This PR addresses the following problem / context:_
- Need a central, polymorphic log for all time-variant operational statuses (e.g., Use Status, Access Status)

### **How**
_Implementation summary - the following was changed / added / removed:_
- New `status_history.py` file was created to establish relevant fields.
- A new `HasStatusHistory` mixin was added to the `db/base.py` file.
- Unrelated to the Jira ticket, docstrings were added to the `db/base.py` file to summarize the contents of the file and describe the mixin functionality.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- The `HasStatusHistory` mixin has not yet been added to/inherited by any primary or core tables.