### PR TITLE
feat: create new Deployment model

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -22,6 +22,7 @@ from db.base import Base
 from db.asset import *
 from db.collabnet import *
 from db.contact import *
+from db.deployment import *
 from db.geochronology import *
 from db.geothermal import *
 from db.field import *

--- a/db/deployment.py
+++ b/db/deployment.py
@@ -24,10 +24,10 @@ class Deployment(Base, AutoBaseMixin, ReleaseMixin):
 
     # --- Foreign Keys ---
     thing_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("thing.thing_id"), nullable=False
+        Integer, ForeignKey("thing.id"), nullable=False
     )
     sensor_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("sensor.sensor_id"), nullable=False
+        Integer, ForeignKey("sensor.id"), nullable=False
     )
 
     # --- Columns ---

--- a/db/deployment.py
+++ b/db/deployment.py
@@ -1,0 +1,47 @@
+"""
+This table is an installation log that creates a many-to-many relationship
+between Things and Equipment, tracking which piece of hardware was installed
+at which Thing and for what period of time.
+"""
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Integer, ForeignKey, String, Date, Numeric, Text
+from sqlalchemy.orm import relationship, Mapped, mapped_column
+
+from db.base import Base, AutoBaseMixin, ReleaseMixin, lexicon_term
+
+if TYPE_CHECKING:
+    from db.thing import Thing
+    from db.sensor import Sensor
+
+
+class Deployment(Base, AutoBaseMixin, ReleaseMixin):
+    """
+    Represents the installation of a specific piece of equipment (Sensor) at a Thing
+    for a defined period. This is an Association Object.
+    """
+
+    # --- Foreign Keys ---
+    thing_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("thing.thing_id"), nullable=False
+    )
+    sensor_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("sensor.sensor_id"), nullable=False
+    )
+
+    # --- Columns ---
+    installation_date: Mapped[Date] = mapped_column(Date, nullable=False)
+    removal_date: Mapped[Date] = mapped_column(Date, nullable=True)
+    recording_interval: Mapped[int] = mapped_column(String(50), nullable=True)
+    recording_interval_units: Mapped[str] = lexicon_term(nullable=True)
+    hanging_cable_length: Mapped[float] = mapped_column(Numeric, nullable=True)
+    hanging_point_height: Mapped[float] = mapped_column(Numeric, nullable=True)
+    hanging_point_description: Mapped[str] = mapped_column(Text, nullable=True)
+    notes: Mapped[str] = mapped_column(Text, nullable=True)
+
+    # --- Relationships ---
+    # Many-To-One: A Deployment is for one Thing.
+    thing: Mapped["Thing"] = relationship("Thing", back_populates="deployments")
+    # Many-To-One: A Deployment is of one piece of equipment (sensor).
+    sensor: Mapped["Sensor"] = relationship("Sensor", back_populates="deployments")

--- a/db/deployment.py
+++ b/db/deployment.py
@@ -1,12 +1,12 @@
 """
 This table is an installation log that creates a many-to-many relationship
-between Things and Equipment, tracking which piece of hardware was installed
+between Things and Sensors, tracking which piece of hardware was installed
 at which Thing and for what period of time.
 """
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Integer, ForeignKey, String, Date, Numeric, Text
+from sqlalchemy import Integer, ForeignKey, Date, Numeric, Text
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from db.base import Base, AutoBaseMixin, ReleaseMixin, lexicon_term
@@ -33,7 +33,7 @@ class Deployment(Base, AutoBaseMixin, ReleaseMixin):
     # --- Columns ---
     installation_date: Mapped[Date] = mapped_column(Date, nullable=False)
     removal_date: Mapped[Date] = mapped_column(Date, nullable=True)
-    recording_interval: Mapped[int] = mapped_column(String(50), nullable=True)
+    recording_interval: Mapped[int] = mapped_column(Integer, nullable=True)
     recording_interval_units: Mapped[str] = lexicon_term(nullable=True)
     hanging_cable_length: Mapped[float] = mapped_column(Numeric, nullable=True)
     hanging_point_height: Mapped[float] = mapped_column(Numeric, nullable=True)

--- a/db/sensor.py
+++ b/db/sensor.py
@@ -24,9 +24,9 @@ from db.base import Base, AutoBaseMixin, ReleaseMixin
 from typing import List, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .deployment import Deployment
-    from .thing import Thing
-    from .observation import Observation
+    from db.deployment import Deployment
+    from db.thing import Thing
+    from db.observation import Observation
 
 
 class Sensor(Base, AutoBaseMixin, ReleaseMixin):

--- a/db/sensor.py
+++ b/db/sensor.py
@@ -16,9 +16,17 @@
 from datetime import datetime
 
 from sqlalchemy import String, Integer, DateTime
+from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.orm import relationship, mapped_column, Mapped
 
 from db.base import Base, AutoBaseMixin, ReleaseMixin
+
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .deployment import Deployment
+    from .thing import Thing
+    from .observation import Observation
 
 
 class Sensor(Base, AutoBaseMixin, ReleaseMixin):
@@ -40,10 +48,21 @@ class Sensor(Base, AutoBaseMixin, ReleaseMixin):
     recording_interval: Mapped[int] = mapped_column(Integer, nullable=True)
     notes: Mapped[str] = mapped_column(String(50), nullable=True)
 
-    observations: Mapped[list["Observation"]] = relationship(  # noqa: F821
+    # --- Relationships ---
+    # One-To-Many: A piece of Equipment can generate many Observations.
+    observations: Mapped[List["Observation"]] = relationship(  # noqa: F821
         "Observation",
         back_populates="sensor",
     )
+
+    # One-To-Many: A Sensor (or piece of equipment) can have many Deployments over its lifetime.
+    deployments: Mapped[List["Deployment"]] = relationship(
+        "Deployment", back_populates="sensor"
+    )
+
+    # --- Association Proxies ---
+    # Proxy to directly access the Things where this Equipment has been deployed.
+    things: AssociationProxy[List["Thing"]] = association_proxy("deployments", "thing")
 
 
 # ============= EOF =============================================

--- a/db/thing.py
+++ b/db/thing.py
@@ -109,7 +109,7 @@ class Thing(Base, AutoBaseMixin, ReleaseMixin):
 
     # --- Association Proxies ---
     # Proxy to directly access the Sensor deployed at this Thing.
-    sensor: AssociationProxy[List["Sensor"]] = association_proxy(
+    sensors: AssociationProxy[List["Sensor"]] = association_proxy(
         "deployments", "sensor"
     )
 

--- a/db/thing.py
+++ b/db/thing.py
@@ -22,6 +22,15 @@ from db import lexicon_term
 from db.asset import Asset
 from db.base import AutoBaseMixin, Base, ReleaseMixin
 
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from db.location import Location
+    from db.field import FieldEvent
+    from db.deployment import Deployment
+    from db.sensor import Sensor
+    from db.contact import Contact
+
 
 class Thing(Base, AutoBaseMixin, ReleaseMixin):
 
@@ -87,8 +96,21 @@ class Thing(Base, AutoBaseMixin, ReleaseMixin):
         )
     )
 
-    field_events = relationship(
+    # --- Relationships ---
+    # One-To-Many: A Thing can have many FieldEvents over time.
+    field_events: Mapped[List["FieldEvent"]] = relationship(
         "FieldEvent", back_populates="thing", cascade="all, delete-orphan", uselist=True
+    )
+
+    # One-To-Many: A Thing can have many Deployments of sensors (equipment) over time.
+    deployments: Mapped[List["Deployment"]] = relationship(
+        "Deployment", back_populates="thing", cascade="all, delete-orphan"
+    )
+
+    # --- Association Proxies ---
+    # Proxy to directly access the Sensor deployed at this Thing.
+    sensor: AssociationProxy[List["Sensor"]] = association_proxy(
+        "deployments", "sensor"
     )
 
 


### PR DESCRIPTION
<!--
- BDMS-156: Create Deployment table
-->
### **Why**
_This PR addresses the following problem / context:_
- Create new Deployment table to manage the many-to-many relationship between `Things` and `Sensors`.
- Allows the storage of a complete, auditable history of which specific piece of physical hardware (**`Sensor`**) was installed at which `Thing` and for what period of time.

### **How**
_Implementation summary - the following was changed / added / removed:_
- Create Deployment model and populate with appropriate fields and relationships.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- This PR addresses the creation of the `Deployment` table only.
- Related validation schema files and test files still need to be created or updated.
- Relationships to the Deployment table still need to be defined in the core tables (`Thing`, `Sensor`).
- Transfer script needs to be created.