### PR TITLE
NO TICKET: fix thing_id query parameter for /sensor

### DIFF
--- a/api/sensor.py
+++ b/api/sensor.py
@@ -26,7 +26,7 @@ from core.dependencies import (
     editor_dependency,
     viewer_dependency,
 )
-from db import Observation, Sample, Sensor, FieldActivity, FieldEvent, Thing
+from db import Observation, Sensor, Deployment, Thing
 from schemas.sensor import SensorResponse, CreateSensor, UpdateSensor
 from services.crud_helper import model_patcher, model_deleter, model_adder
 from services.exceptions_helper import PydanticStyleException
@@ -138,28 +138,25 @@ async def get_sensors(
     This endpoint is a placeholder and should be implemented with actual logic.
     """
     sql = select(Sensor)
-    # TODO: a sensor is not yet related to observation, so this won't work at the moment
     if thing_id is not None or observed_property is not None:
         conditions = []
         joins = []
         if observed_property is not None:
+            joins.append(Observation)
             conditions.append(Observation.observed_property == observed_property)
 
-        # TODO: update after Deployment table is implemented
         if thing_id is not None:
-            # Observation is joined for all filters
-            joins.append(Sample)
-            joins.append(FieldActivity)
-            joins.append(FieldEvent)
+            joins.append(Deployment)
             joins.append(Thing)
             conditions.append(Thing.id == thing_id)
 
-        if conditions:
-            sql = sql.join(Observation)
+        if joins:
             for j in joins:
                 sql = sql.join(j)
 
+        if conditions:
             sql = sql.where(and_(*conditions))
+    print(sql)
 
     sql = order_sort_filter(sql, Sensor, sort=sort, order=order, filter_=filter_)
     return paginate(conn=session, query=sql)

--- a/api/sensor.py
+++ b/api/sensor.py
@@ -156,7 +156,6 @@ async def get_sensors(
 
         if conditions:
             sql = sql.where(and_(*conditions))
-    print(sql)
 
     sql = order_sort_filter(sql, Sensor, sort=sort, order=order, filter_=filter_)
     return paginate(conn=session, query=sql)

--- a/api/sensor.py
+++ b/api/sensor.py
@@ -26,7 +26,7 @@ from core.dependencies import (
     editor_dependency,
     viewer_dependency,
 )
-from db import Observation, Sample, Sensor
+from db import Observation, Sample, Sensor, FieldActivity, FieldEvent, Thing
 from schemas.sensor import SensorResponse, CreateSensor, UpdateSensor
 from services.crud_helper import model_patcher, model_deleter, model_adder
 from services.exceptions_helper import PydanticStyleException
@@ -145,9 +145,14 @@ async def get_sensors(
         if observed_property is not None:
             conditions.append(Observation.observed_property == observed_property)
 
+        # TODO: update after Deployment table is implemented
         if thing_id is not None:
+            # Observation is joined for all filters
             joins.append(Sample)
-            conditions.append(Sample.thing_id == thing_id)
+            joins.append(FieldActivity)
+            joins.append(FieldEvent)
+            joins.append(Thing)
+            conditions.append(Thing.id == thing_id)
 
         if conditions:
             sql = sql.join(Observation)

--- a/core/lexicon.json
+++ b/core/lexicon.json
@@ -114,6 +114,9 @@
   {"categories": [{"name": "unit", "description": null}], "term": "deg C", "definition": "degree Celsius"},
   {"categories": [{"name": "unit", "description": null}], "term": "deg second", "definition": "degree second"},
   {"categories": [{"name": "unit", "description": null}], "term": "deg minute", "definition": "degree minute"},
+  {"categories": [{"name": "unit", "description": null}], "term": "second", "definition": "second"},
+  {"categories": [{"name": "unit", "description": null}], "term": "minute", "definition": "minute"},
+  {"categories": [{"name": "unit", "description": null}], "term": "hour", "definition": "hour"},
 
   {"categories": [{"name": "observed_property", "description": null}], "term": "groundwater level", "definition": "groundwater level measurement" },
   {"categories": [{"name": "observed_property", "description": null}], "term": "temperature", "definition": "Temperature measurement"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,26 @@ def second_sensor():
 
 
 @pytest.fixture(scope="session")
+def sensor_to_water_well_thing_deployment(sensor, water_well_thing):
+    with session_ctx() as session:
+        deployment = Deployment(
+            sensor_id=sensor.id,
+            thing_id=water_well_thing.id,
+            installation_date="2023-01-01",
+            removal_date=None,
+            recording_interval=24,
+            recording_interval_units="hour",
+            hanging_cable_length=10,
+            hanging_point_height=0,
+            hanging_point_description="hang 10",
+            notes="deployment fixture",
+        )
+        session.add(deployment)
+        session.commit()
+        yield deployment
+
+
+@pytest.fixture(scope="session")
 def contact(water_well_thing):
     with session_ctx() as session:
         contact = Contact(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -161,13 +161,9 @@ def test_get_sensors(sensor):
     assert data["items"][0]["notes"] == sensor.notes
 
 
-# TODO: update after Deployment table is implemented
 def test_get_sensors_by_thing_id(
     sensor,
-    water_chemistry_observation,
-    water_chemistry_sample,
-    water_chemistry_field_activity,
-    field_event,
+    sensor_to_water_well_thing_deployment,
     water_well_thing,
 ):
     response = client.get(f"/sensor?thing_id={water_well_thing.id}")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -161,6 +161,33 @@ def test_get_sensors(sensor):
     assert data["items"][0]["notes"] == sensor.notes
 
 
+# TODO: update after Deployment table is implemented
+def test_get_sensors_by_thing_id(
+    sensor,
+    water_chemistry_observation,
+    water_chemistry_sample,
+    water_chemistry_field_activity,
+    field_event,
+    water_well_thing,
+):
+    response = client.get(f"/sensor?thing_id={water_well_thing.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["id"] == sensor.id
+    assert data["items"][0]["created_at"] == sensor.created_at.isoformat().replace(
+        "+00:00", "Z"
+    )
+    assert data["items"][0]["release_status"] == sensor.release_status
+    assert data["items"][0]["name"] == sensor.name
+    assert data["items"][0]["model"] == sensor.model
+    assert data["items"][0]["serial_no"] == sensor.serial_no
+    assert data["items"][0]["datetime_installed"] == sensor.datetime_installed
+    assert data["items"][0]["datetime_removed"] == sensor.datetime_removed
+    assert data["items"][0]["recording_interval"] == sensor.recording_interval
+    assert data["items"][0]["notes"] == sensor.notes
+
+
 def test_get_sensor_by_id(sensor):
     response = client.get(f"/sensor/{sensor.id}")
     assert response.status_code == 200


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- the query parameter `?thing_id` broke for `/sensor` because a `sensor` was no longer easily connected to a `thing` via a `sample`

### **How**
_Implementation summary - the following was changed / added / removed:_
- The `deployment` table is now used as the intermediary

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- This gets *all* sensors related to a thing, regardless of its installation status (`installation_date`/`removal_date`). Is this the behavior we want, or should it only retrieve sensors that are currently installed at a thing?
