### PR TITLE
feat: add lexicon permissions dependencies for editor and admin roles

### DIFF
--- a/api/lexicon.py
+++ b/api/lexicon.py
@@ -59,9 +59,7 @@ from services.query_helper import (
     simple_get_by_id,
 )
 
-router = APIRouter(
-    prefix="/lexicon", tags=["lexicon"]
-)
+router = APIRouter(prefix="/lexicon", tags=["lexicon"])
 
 
 def database_error_handler(
@@ -121,7 +119,9 @@ async def add_category(
     status_code=HTTP_201_CREATED,
 )
 async def add_term(
-    term_data: CreateLexiconTerm, session: session_dependency, user: lexicon_admin_dependency
+    term_data: CreateLexiconTerm,
+    session: session_dependency,
+    user: lexicon_admin_dependency,
 ) -> LexiconTermResponse:
     """
     Endpoint to add a term to the lexicon.

--- a/api/lexicon.py
+++ b/api/lexicon.py
@@ -30,6 +30,8 @@ from core.dependencies import (
     editor_dependency,
     admin_dependency,
     viewer_function,
+    lexicon_editor_dependency,
+    lexicon_admin_dependency,
 )
 from db.lexicon import (
     LexiconCategory,
@@ -58,7 +60,7 @@ from services.query_helper import (
 )
 
 router = APIRouter(
-    prefix="/lexicon", tags=["lexicon"], dependencies=[Depends(viewer_function)]
+    prefix="/lexicon", tags=["lexicon"]
 )
 
 
@@ -105,7 +107,7 @@ def database_error_handler(
 async def add_category(
     category_data: CreateLexiconCategory,
     session: session_dependency,
-    user: admin_dependency,
+    user: lexicon_admin_dependency,
 ) -> LexiconCategoryResponse:
     """
     Endpoint to add a category to the lexicon.
@@ -119,7 +121,7 @@ async def add_category(
     status_code=HTTP_201_CREATED,
 )
 async def add_term(
-    term_data: CreateLexiconTerm, session: session_dependency, user: admin_dependency
+    term_data: CreateLexiconTerm, session: session_dependency, user: lexicon_admin_dependency
 ) -> LexiconTermResponse:
     """
     Endpoint to add a term to the lexicon.
@@ -138,7 +140,7 @@ async def add_term(
 async def add_triple(
     triple_data: CreateLexiconTriple,
     session: session_dependency,
-    user: admin_dependency,
+    user: lexicon_admin_dependency,
 ) -> LexiconTripleResponse:
     triple_data = triple_data.model_dump()
     subject = triple_data["subject"]
@@ -155,7 +157,7 @@ async def update_lexicon_term(
     term_id: int,
     term_data: UpdateLexiconTerm,
     session: session_dependency,
-    user: editor_dependency,
+    user: lexicon_editor_dependency,
 ) -> LexiconTermResponse:
 
     return model_patcher(session, LexiconTerm, term_id, term_data, user=user)
@@ -166,7 +168,7 @@ async def update_lexicon_category(
     category_id: int,
     category_data: UpdateLexiconCategory,
     session: session_dependency,
-    user: editor_dependency,
+    user: lexicon_editor_dependency,
 ) -> LexiconCategoryResponse:
     return model_patcher(
         session, LexiconCategory, category_id, category_data, user=user
@@ -178,7 +180,7 @@ async def update_lexicon_triple(
     triple_id: int,
     triple_data: UpdateLexiconTriple,
     session: session_dependency,
-    user: editor_dependency,
+    user: lexicon_editor_dependency,
 ) -> LexiconTripleResponse:
     try:
         return model_patcher(session, LexiconTriple, triple_id, triple_data, user=user)

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -15,7 +15,7 @@
 # ===============================================================================
 from typing import Annotated, Callable
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from core.permissions import authenticated
@@ -44,12 +44,27 @@ amp_viewer_function = authenticated(permissions=["AMPViewer"])
 # for testing
 no_permission_function = authenticated(permissions=["NoPermission"])
 
+lexicon_editor = authenticated(permissions=["LexiconEditor"])
+lexicon_admin = authenticated(permissions=["LexiconAdmin"])
+def _unauthorized(func):
+    user = func()
+    if not user:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+def lexicon_admin_function():
+    return _unauthorized(lexicon_admin)
+
+def lexicon_editor_function():
+    return _unauthorized(lexicon_editor)
+
 
 # permissions dependencies
 admin_dependency = Annotated[Callable, Depends(admin_function)]
 editor_dependency = Annotated[Callable, Depends(editor_function)]
 viewer_dependency = Annotated[Callable, Depends(viewer_function)]
 
+lexicon_admin_dependency = Annotated[Callable, Depends(lexicon_admin_function)]
+lexicon_editor_dependency = Annotated[Callable, Depends(lexicon_editor_function)]
 
 amp_admin_dependency = Annotated[Callable, Depends(amp_admin_function)]
 amp_editor_dependency = Annotated[Callable, Depends(amp_editor_function)]

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -46,13 +46,17 @@ no_permission_function = authenticated(permissions=["NoPermission"])
 
 lexicon_editor = authenticated(permissions=["LexiconEditor"])
 lexicon_admin = authenticated(permissions=["LexiconAdmin"])
+
+
 def _unauthorized(func):
     user = func()
     if not user:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
+
 def lexicon_admin_function():
     return _unauthorized(lexicon_admin)
+
 
 def lexicon_editor_function():
     return _unauthorized(lexicon_editor)

--- a/tests/test_lexicon.py
+++ b/tests/test_lexicon.py
@@ -16,7 +16,7 @@
 from db import LexiconTerm, LexiconCategory, LexiconTriple
 from tests import client, override_authentication, cleanup_post_test, cleanup_patch_test
 
-from core.dependencies import admin_function, viewer_function, editor_function
+from core.dependencies import viewer_function, editor_function, lexicon_admin_function, lexicon_editor_function
 from main import app
 
 import pytest
@@ -25,10 +25,10 @@ import pytest
 @pytest.fixture(scope="module", autouse=True)
 def override_authentication_dependency_fixture():
 
-    app.dependency_overrides[admin_function] = override_authentication(
+    app.dependency_overrides[lexicon_admin_function] = override_authentication(
         default={"name": "foobar", "sub": "1234567890"}
     )
-    app.dependency_overrides[editor_function] = override_authentication(
+    app.dependency_overrides[lexicon_editor_function] = override_authentication(
         default={"name": "foobar", "sub": "1234567890"}
     )
     app.dependency_overrides[viewer_function] = override_authentication()

--- a/tests/test_lexicon.py
+++ b/tests/test_lexicon.py
@@ -16,7 +16,12 @@
 from db import LexiconTerm, LexiconCategory, LexiconTriple
 from tests import client, override_authentication, cleanup_post_test, cleanup_patch_test
 
-from core.dependencies import viewer_function, editor_function, lexicon_admin_function, lexicon_editor_function
+from core.dependencies import (
+    viewer_function,
+    editor_function,
+    lexicon_admin_function,
+    lexicon_editor_function,
+)
 from main import app
 
 import pytest

--- a/transfers/waterlevels_transfer.py
+++ b/transfers/waterlevels_transfer.py
@@ -70,7 +70,7 @@ def transfer_water_levels(session):
                 fmt = "%Y-%m-%d %H:%M:%S.%f"
                 t = row.TimeMeasured
                 # Truncate microseconds to 6 digits if present
-                if '.' in t:
+                if "." in t:
                     t = t[:-6]
 
                 dt_measured = f"{row.DateMeasured} {t}"


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- Wanted to elevate the permission necessary to edit/admin the lexicon

### **How**
_Implementation summary - the following was changed / added / removed:_
- added lexicon_editor and lexicon_admin dependencies
- added LexiconEditor and LexiconAdmin permissions to authentik

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- @chasetmartin we need to update the Access Control rules in OcotilloUI to set authorization for Lexicon UI components
