### PR TITLE
[NO TICKET] Make senor_id nullable

### DIFF
--- a/schemas/observation.py
+++ b/schemas/observation.py
@@ -102,7 +102,7 @@ class UpdateWaterChemistryObservation(UpdateBaseObservation):
 # TODO: Return full sample and sensor objects
 class BaseObservationResponse(BaseResponseModel):
     sample_id: int
-    sensor_id: int
+    sensor_id: int | None
     observation_datetime: AwareDatetime
     parameter: ParameterResponse
     release_status: str


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem / context:_
- Because of the data currently able to be transferred from the transfer scripts, `senor_id` is null more often than not, causing a 500 server error and leading to frontend missing data for dev and testing. 

### **How**
_Implementation summary - the following was changed / added / removed:_
- Update `senor_id` field in  `schemas/observation/BaseObservationResponse` nullable

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- This is a temporary solution 
