### PR TITLE
NO TICKET: datetime format fix, README update, enums

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,8 @@ POSTGRES_DB=
 GCS_BUCKET_NAME=
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/gcs_credentials.json
 
-
+# set to development for lexicon and parameter to be populated and enable the enums to work
+MODE=development
 
 # disable authentication (for development only)
 AUTHENTIK_DISABLE_AUTHENTICATION=1

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ pre-commit install
 cp .env.example .env
 ```
 
+In development set `MODE=development` to allow lexicon enums to be populated.
+
 #### 5. Database and server
 
 

--- a/core/enums.py
+++ b/core/enums.py
@@ -66,4 +66,5 @@ ThingType: type[Enum] = build_enum_from_lexicon_category("thing_type")
 Unit: type[Enum] = build_enum_from_lexicon_category("unit")
 Vertical_datum: type[Enum] = build_enum_from_lexicon_category("vertical_datum")
 ScreenType: type[Enum] = build_enum_from_lexicon_category("screen_type")
+SensorType: type[Enum] = build_enum_from_lexicon_category("sensor_type")
 # ============= EOF =============================================

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -20,14 +20,13 @@ from pydantic import (
     ConfigDict,
     AwareDatetime,
     field_validator,
-    model_serializer,
 )
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import core_schema
 
 from core.enums import ReleaseStatus
 
-DT_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
+DT_FMT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 class ResourceNotFoundResponse(BaseModel):
@@ -68,7 +67,7 @@ class UTCAwareDatetime(AwareDatetime):
             if value.tzinfo != timezone.utc:
                 value = value.astimezone(timezone.utc)
             # Format with Z suffix
-            return value.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            return value.strftime(DT_FMT)
 
         # Use generate_schema instead of calling handler directly
         python_schema = handler.generate_schema(datetime)
@@ -97,14 +96,6 @@ class BaseResponseModel(BaseModel):
         from_attributes=True,
         populate_by_name=True,
     )
-
-    @model_serializer
-    def serialize(self):
-        data = self.__dict__.copy()
-        # If release_status is an enum, convert to string
-        if hasattr(data.get("release_status"), "value"):
-            data["release_status"] = data["release_status"].value
-        return data
 
 
 # TODO: write function to convert any datetime field to UTC for use throughout

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -27,6 +27,8 @@ from pydantic_core import core_schema
 
 from core.enums import ReleaseStatus
 
+DT_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
 
 class ResourceNotFoundResponse(BaseModel):
     detail: str

--- a/schemas/field.py
+++ b/schemas/field.py
@@ -1,14 +1,14 @@
 from pydantic import AwareDatetime
 
 from schemas import BaseResponseModel
-
+from core.enums import ActivityType
 
 # RESPONSE ---------------------------------------------------------------------
 
 
 class FieldActivityResponse(BaseResponseModel):
     field_event_id: int
-    activity_type: str
+    activity_type: ActivityType
 
 
 class FieldEventResponse(BaseResponseModel):

--- a/schemas/location.py
+++ b/schemas/location.py
@@ -70,11 +70,11 @@ class LocationResponse(BaseResponseModel):
     point: str
     elevation: float | None
     horizontal_datum: str = "WGS84"
-    vertical_daum: str = "NAVD88"
+    vertical_datum: str = "NAVD88"
     elevation_accuracy: float | None
-    elevation_method: str | None
+    elevation_method: ElevationMethod | None
     coordinate_accuracy: float | None
-    coordinate_method: str | None
+    coordinate_method: CoordinateMethod | None
     state: str | None
     county: str | None
     quad_name: str | None

--- a/schemas/observation.py
+++ b/schemas/observation.py
@@ -32,7 +32,7 @@ from schemas import (
     UTCAwareDatetime,
 )
 from schemas.parameter import ParameterResponse
-
+from core.enums import Unit
 
 # class GeothermalMixin:
 #     depth: float
@@ -69,7 +69,7 @@ class CreateBaseObservation(BaseCreateModel, ValidateObservation):
     sensor_id: int
     parameter_id: int
     value: float | None
-    unit: str | None
+    unit: Unit | None
 
 
 class CreateGroundwaterLevelObservation(CreateBaseObservation):
@@ -90,7 +90,7 @@ class UpdateBaseObservation(BaseUpdateModel, ValidateObservation):
     sensor_id: int | None = None
     parameter_id: int | None = None
     value: float | None | None = None
-    unit: str | None = None
+    unit: Unit | None = None
 
 
 class UpdateGroundwaterLevelObservation(UpdateBaseObservation):
@@ -110,7 +110,7 @@ class BaseObservationResponse(BaseResponseModel):
     observation_datetime: UTCAwareDatetime
     parameter: ParameterResponse
     value: float | None
-    unit: str
+    unit: Unit
 
 
 class GroundwaterLevelObservationResponse(BaseObservationResponse):

--- a/schemas/parameter.py
+++ b/schemas/parameter.py
@@ -1,4 +1,5 @@
 from schemas import BaseResponseModel
+from core.enums import ParameterType, ParameterName, Unit
 
 
 # -------- RESPONSE -------
@@ -8,8 +9,8 @@ class ParameterResponse(BaseResponseModel):
     This model can be extended to include additional fields as needed.
     """
 
-    parameter_name: str
+    parameter_name: ParameterName
     matrix: str
-    parameter_type: str | None
+    parameter_type: ParameterType | None
     cas_number: str | None
-    default_unit: str
+    default_unit: Unit | None

--- a/schemas/publication.py
+++ b/schemas/publication.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ===============================================================================
 from pydantic import BaseModel
+from core.enums import PublicationType
 
 
 # -------- CREATE ----------
@@ -28,7 +29,7 @@ class CreatePublication(BaseModel):
     doi: str | None = None
     url: str | None = None
 
-    publication_type: str
+    publication_type: PublicationType
 
 
 # -------- RESPONSE ----------
@@ -54,7 +55,7 @@ class PublicationResponse(BaseModel):
     year: int
     doi: str | None = None
     url: str | None = None
-    publication_type: str
+    publication_type: PublicationType
 
 
 # -------- UPDATE ----------

--- a/schemas/sample.py
+++ b/schemas/sample.py
@@ -133,9 +133,9 @@ class SampleResponse(BaseResponseModel):
     contact: ContactResponse
     sample_date: UTCAwareDatetime
     sample_name: str
-    sample_matrix: str
-    sample_method: str
-    qc_type: str
+    sample_matrix: SampleMatrix
+    sample_method: SampleMethod
+    qc_type: SampleQcType
     notes: str | None
     depth_top: float | None
     depth_bottom: float | None

--- a/schemas/sensor.py
+++ b/schemas/sensor.py
@@ -22,7 +22,7 @@
 #     model_validator,
 #     field_validator,
 # )
-
+from core.enums import SensorType
 from schemas import BaseCreateModel, BaseUpdateModel, BaseResponseModel
 
 # ------- VALIDATION ------
@@ -58,7 +58,7 @@ class CreateSensor(BaseCreateModel):
     """
 
     name: str
-    sensor_type: str
+    sensor_type: SensorType
     model: str | None = None
     serial_no: str | None = None
     pcn_number: str | None = None
@@ -70,7 +70,7 @@ class CreateSensor(BaseCreateModel):
 # -------- UPDATE ----------
 class UpdateSensor(BaseUpdateModel):
     name: str | None = None
-    sensor_type: str | None = None
+    sensor_type: SensorType | None = None
     model: str | None = None
     serial_no: str | None = None
     pcn_number: str | None = None
@@ -82,7 +82,7 @@ class UpdateSensor(BaseUpdateModel):
 # -------- RESPONSE ----------
 class SensorResponse(BaseResponseModel):
     name: str
-    sensor_type: str
+    sensor_type: SensorType
     model: str | None  # = Column(String(50))
     serial_no: str | None  # = Column(String(50))
     pcn_number: str | None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -74,8 +74,6 @@ with session_ctx() as session:
 groundwater_level_parameter_id = parameter_map[("groundwater level", "Field Parameter")]
 pH_parameter_id = parameter_map[("pH", "Field Parameter")]
 
-DT_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
-
 
 def override_authentication(default=True):
     """

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -22,12 +22,12 @@ from api.asset import get_storage_bucket
 from core.app import app
 from core.dependencies import viewer_function, admin_function, editor_function
 from db import Asset
+from schemas import DT_FMT
 from tests import (
     client,
     cleanup_post_test,
     override_authentication,
     cleanup_patch_test,
-    DT_FMT,
 )
 
 

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -11,13 +11,13 @@ from core.dependencies import (
 )
 from db import Contact, Address, Email, Phone
 from main import app
+from schemas import DT_FMT
 from schemas.contact import ValidateEmail, ValidatePhone, ValidateContact
 from tests import (
     client,
     cleanup_post_test,
     cleanup_patch_test,
     override_authentication,
-    DT_FMT,
 )
 
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -7,13 +7,13 @@ from pydantic import ValidationError
 from core.dependencies import admin_function, viewer_function, editor_function
 from db import Group
 from main import app
+from schemas import DT_FMT
 from schemas.group import ValidateGroup
 from tests import (
     client,
     override_authentication,
     cleanup_post_test,
     cleanup_patch_test,
-    DT_FMT,
 )
 
 

--- a/tests/test_lexicon.py
+++ b/tests/test_lexicon.py
@@ -24,12 +24,12 @@ from core.dependencies import (
 )
 from db import LexiconTerm, LexiconCategory, LexiconTriple
 from main import app
+from schemas import DT_FMT
 from tests import (
     client,
     override_authentication,
     cleanup_post_test,
     cleanup_patch_test,
-    DT_FMT,
 )
 
 

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -21,12 +21,12 @@ from geoalchemy2.shape import to_shape
 from core.dependencies import admin_function, editor_function, viewer_function
 from db import Location
 from main import app
+from schemas import DT_FMT
 from tests import (
     client,
     override_authentication,
     cleanup_post_test,
     cleanup_patch_test,
-    DT_FMT,
 )
 
 

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -27,6 +27,7 @@ from core.dependencies import (
 )
 from db import Observation
 from main import app
+from schemas import DT_FMT
 from tests import (
     client,
     cleanup_post_test,
@@ -34,7 +35,6 @@ from tests import (
     cleanup_patch_test,
     groundwater_level_parameter_id,
     pH_parameter_id,
-    DT_FMT,
 )
 
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -21,13 +21,13 @@ from pydantic import ValidationError
 from core.dependencies import admin_function, editor_function, viewer_function
 from db.sample import Sample
 from main import app
+from schemas import DT_FMT
 from schemas.sample import ValidateSample
 from tests import (
     client,
     cleanup_post_test,
     cleanup_patch_test,
     override_authentication,
-    DT_FMT,
 )
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -23,13 +23,13 @@ from db import Sensor
 from main import app
 
 # from schemas.sensor import ValidateSensor
+from schemas import DT_FMT
 from tests import (
     client,
     cleanup_post_test,
     cleanup_patch_test,
     override_authentication,
     groundwater_level_parameter_id,
-    DT_FMT,
 )
 
 

--- a/tests/test_thing.py
+++ b/tests/test_thing.py
@@ -29,12 +29,12 @@ from db import Thing, WellScreen, ThingIdLink
 from main import app
 from schemas.location import LocationResponse
 from schemas.thing import ValidateWell
+from schemas import DT_FMT
 from tests import (
     client,
     override_authentication,
     cleanup_post_test,
     cleanup_patch_test,
-    DT_FMT,
 )
 
 


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- @chasetmartin and I were having trouble pulling data when developing locally because of an enum issue, but then we figured out it was as easy as setting `MODE=development` in `.env` because otherwise the enums are made before the lexicon tables are populated. Once we determined this was the issue we thought updating `.env.example` and `README` would suffice for future developers
- In the process of figuring out this problem, we found that the `@model_serializer` was not necessary for the `BaseResponseModel`
- Not all enum-restricted fields used those enums in their `Create`, `Update`, and `Response` models

### **How**
_Implementation summary - the following was changed / added / removed:_
- Use bullet points here

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
-  I put `DT_FMT` in `schemas/__init__.py` from `tests/__init__.py` so it can be used in both schemas and tests. I also removed microseconds from the format as that seemed extraneous.
- @jirhiker: currently lexicon and parameter tables are only populated on spinup if `MODE=development`. Does it populate it for production? If not should it?
