### PR TITLE
NO TICKET: make run_bdd.sh useable for Windows | ensure on main branch

### DIFF
--- a/run_bdd.sh
+++ b/run_bdd.sh
@@ -15,7 +15,13 @@ if [ ! -d ".venv" ]; then
   echo "🧱 Creating virtual environment..."
   python3 -m venv venv
 fi
-source .venv/bin/activate
+
+# bin for Unix, Scripts for Windows
+if [ -d ".venv/bin" ]; then
+  source .venv/bin/activate
+else
+  source .venv/Scripts/activate
+fi
 
 # Install dependencies
 echo "📦 Installing Python dependencies..."

--- a/run_bdd.sh
+++ b/run_bdd.sh
@@ -42,7 +42,13 @@ fi
 # Copy backend features
 echo "📋 Syncing backend features..."
 mkdir -p tests/features
-rsync -a ../OcotilloBDD/features/backend/ tests/features/
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" || "$OSTYPE" == "win64" || "$OSTYPE" == "cygwin" ]]; then
+  # Windows
+  cp -r ../OcotilloBDD/features/backend/. tests/features/
+else
+  # Unix/Linux/Mac
+  rsync -a ../OcotilloBDD/features/backend/ tests/features/
+fi
 
 # Run Behave tests
 echo "🚀 Running Behave tests..."

--- a/run_bdd.sh
+++ b/run_bdd.sh
@@ -36,7 +36,7 @@ if [ ! -d "../OcotilloBDD" ]; then
   git clone https://github.com/DataIntegrationGroup/OcotilloBDD.git ../OcotilloBDD
 else
   echo "🔄 Updating existing BDD repository..."
-  cd ../OcotilloBDD && git pull && cd - >/dev/null
+  cd ../OcotilloBDD && git checkout main && git pull && cd - >/dev/null
 fi
 
 # Copy backend features


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- some of the functionality in `run_bdd.sh` is only available for Unix and not Windows
- we need to ensure that we are on the `main` branch before git pulling

### **How**
_Implementation summary - the following was changed / added / removed:_
- Use if statements to determine which functions to use

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Incase someone is working on OcotilloBDD, should we record the branch that is currently checked out, stash the changes, run the tests, then go back to that branch and apply the stash?

```bash
# Save current branch name
CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)

# Stash any uncommitted changes
git stash push -u -m "Auto-stash before BDD run"

# Checkout main and update
git checkout main
git pull

# ... (your BDD test steps here) ...

# Return to your original branch
git checkout "$CURRENT_BRANCH"

# Apply stashed changes if any
if git stash list | grep -q "Auto-stash before BDD run"; then
  git stash pop
fi
```
