### PR TITLE
NO TICKET: delete thing id links on deletion of thing

### DIFF
--- a/db/thing.py
+++ b/db/thing.py
@@ -223,6 +223,13 @@ class Thing(Base, AutoBaseMixin, ReleaseMixin, StatusHistoryMixin, PermissionMix
         lazy="joined",
     )
 
+    links: Mapped[List["ThingIdLink"]] = relationship(
+        "ThingIdLink",
+        back_populates="thing",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
     # --- Association Proxies ---
     assets: AssociationProxy[list["Asset"]] = association_proxy(
         "asset_associations", "asset"
@@ -280,7 +287,7 @@ class ThingIdLink(Base, AutoBaseMixin, ReleaseMixin):
     alternate_id: Mapped[str] = mapped_column(String(100), nullable=False)
     alternate_organization: Mapped[str] = lexicon_term(nullable=False)
 
-    thing: Mapped["Thing"] = relationship("Thing", backref="links")
+    thing: Mapped["Thing"] = relationship("Thing", back_populates="links")
 
 
 class WellScreen(Base, AutoBaseMixin, ReleaseMixin):


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- when a `thing` is deleted its child `thing_id_links` need to be deleted. If not, the `thing_id` field is `NULL`, which breaks the not-null constraint that comes from the foreign key 

### **How**
_Implementation summary - the following was changed / added / removed:_
- add a reference to the `thing_id_link` table in the `thing` table and set `cascade="all, delete-orphan"`

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Use bullet points here
