### PR TITLE
BDMS 221 & 227: function to retrieve polymorphic table record

### DIFF
--- a/services/util.py
+++ b/services/util.py
@@ -116,15 +116,16 @@ def get_epqs_elevation_from_point(lon: float, lat: float) -> float | None:
     return data["value"]
 
 
-def retrieve_polymorphic_table_record(
+def retrieve_latest_polymorphic_table_record(
     target_record: Base,
     polymorphic_relationship: str,
     polymorphic_type: str,
-    latest=True,
 ) -> Base:
     """
-    Retrieve a record from a polymorphic table. This function assumes that the
-    parent class has the correct mixin to support retrieval via an attribute.
+    Retrieve the latest record from a polymorphic table. This function assumes that the
+    parent class has the correct mixin to support retrieval via an attribute. This
+    requires end_date to be None
+
     Parameters:
     ----------
     target_record : Base
@@ -143,10 +144,12 @@ def retrieve_polymorphic_table_record(
 
     polymorphic_records = getattr(target_record, polymorphic_relationship)
     type_polymorphic_records = [
-        r for r in polymorphic_records if getattr(r, type_field) == polymorphic_type
+        r
+        for r in polymorphic_records
+        if getattr(r, type_field) == polymorphic_type and r.end_date is None
     ]
     sorted_type_polymorphic_records = sorted(
-        type_polymorphic_records, key=lambda r: r.start_date, reverse=latest
+        type_polymorphic_records, key=lambda r: r.start_date, reverse=True
     )
     return sorted_type_polymorphic_records[0]
 

--- a/services/util.py
+++ b/services/util.py
@@ -5,6 +5,7 @@ import pyproj
 import httpx
 
 from constants import SRID_WGS84
+from db import Base
 
 TRANSFORMERS = {}
 
@@ -113,6 +114,41 @@ def get_epqs_elevation_from_point(lon: float, lat: float) -> float | None:
         return None
 
     return data["value"]
+
+
+def retrieve_polymorphic_table_record(
+    target_record: Base,
+    polymorphic_relationship: str,
+    polymorphic_type: str,
+    latest=True,
+) -> Base:
+    """
+    Retrieve a record from a polymorphic table. This function assumes that the
+    parent class has the correct mixin to support retrieval via an attribute.
+    Parameters:
+    ----------
+    target_record : Base
+        The parent record from which to retrieve the polymorphic child record.
+    polymorphic_relationship : str
+        The name of the relationship attribute on the parent record that corresponds to the polymorphic table.
+    polymorphic_type : str
+        The specific type of the polymorphic record to retrieve (e.g., 'Use Status' or 'Monitoring Status' for StatusHistory).
+    latest : bool, optional
+        If True, retrieves the latest record based on start_date. Defaults to True.
+    """
+    if polymorphic_relationship == "permissions":
+        type_field = "permission_type"
+    elif polymorphic_relationship == "status_history":
+        type_field = "status_type"
+
+    polymorphic_records = getattr(target_record, polymorphic_relationship)
+    type_polymorphic_records = [
+        r for r in polymorphic_records if getattr(r, type_field) == polymorphic_type
+    ]
+    sorted_type_polymorphic_records = sorted(
+        type_polymorphic_records, key=lambda r: r.start_date, reverse=latest
+    )
+    return sorted_type_polymorphic_records[0]
 
 
 if __name__ == "__main__":

--- a/services/util.py
+++ b/services/util.py
@@ -5,7 +5,6 @@ import pyproj
 import httpx
 
 from constants import SRID_WGS84
-from db import Base
 
 TRANSFORMERS = {}
 
@@ -114,44 +113,6 @@ def get_epqs_elevation_from_point(lon: float, lat: float) -> float | None:
         return None
 
     return data["value"]
-
-
-def retrieve_latest_polymorphic_table_record(
-    target_record: Base,
-    polymorphic_relationship: str,
-    polymorphic_type: str,
-) -> Base:
-    """
-    Retrieve the latest record from a polymorphic table. This function assumes that the
-    parent class has the correct mixin to support retrieval via an attribute. This
-    requires end_date to be None
-
-    Parameters:
-    ----------
-    target_record : Base
-        The parent record from which to retrieve the polymorphic child record.
-    polymorphic_relationship : str
-        The name of the relationship attribute on the parent record that corresponds to the polymorphic table.
-    polymorphic_type : str
-        The specific type of the polymorphic record to retrieve (e.g., 'Use Status' or 'Monitoring Status' for StatusHistory).
-    latest : bool, optional
-        If True, retrieves the latest record based on start_date. Defaults to True.
-    """
-    if polymorphic_relationship == "permissions":
-        type_field = "permission_type"
-    elif polymorphic_relationship == "status_history":
-        type_field = "status_type"
-
-    polymorphic_records = getattr(target_record, polymorphic_relationship)
-    type_polymorphic_records = [
-        r
-        for r in polymorphic_records
-        if getattr(r, type_field) == polymorphic_type and r.end_date is None
-    ]
-    sorted_type_polymorphic_records = sorted(
-        type_polymorphic_records, key=lambda r: r.start_date, reverse=True
-    )
-    return sorted_type_polymorphic_records[0]
 
 
 if __name__ == "__main__":

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -109,4 +109,42 @@ def cleanup_patch_test(model: Base, payload: dict, original_data: Base) -> None:
         session.commit()
 
 
+def retrieve_latest_polymorphic_table_record(
+    target_record: Base,
+    polymorphic_relationship: str,
+    polymorphic_type: str,
+) -> Base:
+    """
+    Retrieve the latest record from a polymorphic table. This function assumes that the
+    parent class has the correct mixin to support retrieval via an attribute. This
+    requires end_date to be None
+
+    Parameters:
+    ----------
+    target_record : Base
+        The parent record from which to retrieve the polymorphic child record.
+    polymorphic_relationship : str
+        The name of the relationship attribute on the parent record that corresponds to the polymorphic table.
+    polymorphic_type : str
+        The specific type of the polymorphic record to retrieve (e.g., 'Use Status' or 'Monitoring Status' for StatusHistory).
+    latest : bool, optional
+        If True, retrieves the latest record based on start_date. Defaults to True.
+    """
+    if polymorphic_relationship == "permissions":
+        type_field = "permission_type"
+    elif polymorphic_relationship == "status_history":
+        type_field = "status_type"
+
+    polymorphic_records = getattr(target_record, polymorphic_relationship)
+    type_polymorphic_records = [
+        r
+        for r in polymorphic_records
+        if getattr(r, type_field) == polymorphic_type and r.end_date is None
+    ]
+    sorted_type_polymorphic_records = sorted(
+        type_polymorphic_records, key=lambda r: r.start_date, reverse=True
+    )
+    return sorted_type_polymorphic_records[0]
+
+
 # ============= EOF =============================================


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- Records from the `parameter` and `status_history` tables need to be easily retrieved for schemas and tests

### **How**
_Implementation summary - the following was changed / added / removed:_
- A function to retrieve a record was put into `services/util.py`

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- This only retrieves one function in a sorted list by `start_date`. I don't think that we need one to retrieve _all_ records since that is easily done via the attribute from the mixins.
