### PR TITLE
NO TICKET: only write to transfer logs for transfer scripts

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,12 +29,16 @@ load_dotenv(override=True)
 
 # time.tzset()
 
-from transfers.transfer import erase_and_initalize
 from fastapi.testclient import TestClient
 from fastapi_pagination import add_pagination
 from starlette.middleware.cors import CORSMiddleware
 
-from core.initializers import init_lexicon, init_parameter, register_routes
+from core.initializers import (
+    init_lexicon,
+    init_parameter,
+    register_routes,
+    erase_and_rebuild_db,
+)
 from db import Base, Parameter
 from db.engine import session_ctx
 from core.app import app
@@ -43,7 +47,7 @@ from core.app import app
 # Base.metadata.drop_all(engine)
 # Base.metadata.create_all(engine)
 with session_ctx() as session:
-    erase_and_initalize(session)
+    erase_and_rebuild_db(session)
 
 init_lexicon()
 init_parameter()


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- the transfer logs should only be written to during transfer scripts, not during tests

### **How**
_Implementation summary - the following was changed / added / removed:_
- remove `from transfers.transfers import erase_and_initalize` from `tests/__init__.py` and use `erase_and_rebuild_db` from `core/initializers.py` instead. Otherwise the transfer logger will be instantiated and used for tests

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Use bullet points here
