### PR TITLE
[NO TICKET] Add db healthcheck to docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       - 5432:5432
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 2s
+      timeout: 5s
+      retries: 20
 
   app:
     build: 
@@ -27,7 +32,8 @@ services:
     ports:
       - 8000:8000
     depends_on:
-      - db
+      db:
+        condition: service_healthy # <-- wait for DB to be ready
     links:
       - db
     volumes:


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem/context:_
- The FastAPI backend container frequently failed to start in GitHub Actions due to PostGIS taking longer to initialize than standard PostgreSQL.
- The application attempted to connect to the database before PostGIS finished booting, causing repeated connection failures (db:5432 - no response / Waiting for postgres.).
- The test workflow’s health check waited on FastAPI, not the underlying database, so even increasing timeouts did not fix the issue.

### **How**
_Implementation summary - the following was changed/added/removed:_
- Added a proper healthcheck to the db service in docker-compose.yml to wait for PostGIS to become ready (pg_isready).
- Updated app service to use depends_on: condition: service_healthy so FastAPI starts only after the database is fully initialized.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Use bullet points here
