### PR TITLE
NO TICKET: add session_ctx to development version init

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -17,6 +17,8 @@ import os
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
+from db.engine import session_ctx
+
 from fastapi import FastAPI
 from fastapi.openapi.docs import (
     get_swagger_ui_html,
@@ -39,7 +41,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     Application lifespan event handler to initialize the database and lexicon.
     """
     if settings.get_enum("MODE") == "development":
-        erase_and_rebuild_db()
+        with session_ctx() as session:
+            erase_and_rebuild_db(session)
         init_lexicon()
         init_parameter()
 


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- I was getting this error on `docker compose up --build`
```
app-1  |   File "/app/core/app.py", line 42, in lifespan                                          
app-1  |     erase_and_rebuild_db()                                                               
app-1  |     ~~~~~~~~~~~~~~~~~~~~^^                                                               
app-1  | TypeError: erase_and_rebuild_db() missing 1 required positional argument: 'session'
```

### **How**
_Implementation summary - the following was changed / added / removed:_
- @jirhiker I'm not confident this is the best way to handle this, but please let me know your thoughts. I believe this is causing all of the issues @TylerAdamMartinez was having with the CI_Cypress workflow on OcotilloUI. The docker compose up command fails without erase_and_rebuild_db() having the session argument. The OcotilloUI github actions uses docker compose up to build the app to test against.
 - I tried a draft PR from OcotilloUI against this branch and the CI_Cypress workflow worked.
 
### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Use bullet points here
