### PR TITLE
BDMS 296: increase limit size for search

### DIFF
--- a/api/search.py
+++ b/api/search.py
@@ -175,7 +175,8 @@ async def search_api(
     user: viewer_dependency,
     session: session_dependency,
     q: str,
-    limit: int = 100,
+    size: int = 100,
+    limit: int = 25,
 ) -> CustomPage[dict]:
     """
     Search endpoint for the collaborative network.

--- a/api/search.py
+++ b/api/search.py
@@ -175,7 +175,7 @@ async def search_api(
     user: viewer_dependency,
     session: session_dependency,
     q: str,
-    limit: int = 25,
+    limit: int = 100,
 ) -> CustomPage[dict]:
     """
     Search endpoint for the collaborative network.


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- A pagination size of 25 is too restrictive

### **How**
_Implementation summary - the following was changed / added / removed:_
- Increased the size to 100

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- I haven't tested a pagination in the search tests, but from the research I've done setting a query parameter called `size` should do the trick.
