### PR TITLE
Fix: Handle measuring_point fields correctly in Thing creation API

### DIFF
--- a/services/thing_helper.py
+++ b/services/thing_helper.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
 from fastapi import Request
 from fastapi_pagination.ext.sqlalchemy import paginate
 from pydantic import BaseModel
@@ -32,6 +35,7 @@ from db import (
     WellCasingMaterial,
 )
 from db.group import GroupThingAssociation
+from db.measuring_point_history import MeasuringPointHistory
 from services.audit_helper import audit_add
 from services.crud_helper import model_patcher
 from services.exceptions_helper import PydanticStyleException
@@ -159,6 +163,10 @@ def add_thing(
     location_id = data.pop("location_id", None)
     group_id = data.pop("group_id", None)
 
+    # Extract measuring point data (stored in separate history table, not as Thing columns)
+    measuring_point_height = data.pop("measuring_point_height", None)
+    measuring_point_description = data.pop("measuring_point_description", None)
+
     try:
         thing = Thing(**data)
         thing.thing_type = thing_type
@@ -168,6 +176,18 @@ def add_thing(
         session.add(thing)
         session.flush()
         session.refresh(thing)
+
+        # Create MeasuringPointHistory record if measuring_point_height provided
+        if measuring_point_height is not None:
+            measuring_point_history = MeasuringPointHistory(
+                thing_id=thing.id,
+                measuring_point_height=measuring_point_height,
+                measuring_point_description=measuring_point_description,
+                start_date=datetime.now(tz=ZoneInfo("UTC")),
+                end_date=None,
+            )
+            audit_add(user, measuring_point_history)
+            session.add(measuring_point_history)
 
         # endpoint catches ProgrammingError if location_id or group_id do not exist
         if group_id:

--- a/tests/test_thing.py
+++ b/tests/test_thing.py
@@ -152,6 +152,35 @@ def test_add_water_well(location, group):
     cleanup_post_test(Thing, data["id"])
 
 
+def test_add_water_well_with_measuring_point(location, group):
+    """
+    Test creating a well with measuring_point_height and measuring_point_description.
+
+    This reproduces the bug where measuring_point fields are properties (from MeasuringPointHistory table)
+    and cannot be set directly on Thing objects.
+
+    Expected error (before fix): AttributeError: property 'measuring_point_height' of 'Thing' object has no setter
+    """
+    payload = {
+        "location_id": location.id,
+        "group_id": group.id,
+        "release_status": "draft",
+        "name": "Test Well with Measuring Point",
+        "measuring_point_height": 2.5,
+        "measuring_point_description": "top of casing",
+    }
+
+    response = client.post("/thing/water-well", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+
+    assert data["name"] == payload["name"]
+    assert data["measuring_point_height"] == 2.5
+    assert data["measuring_point_description"] == "top of casing"
+
+    cleanup_post_test(Thing, data["id"])
+
+
 @pytest.mark.skip("Needs to be updated per changes made from feature files")
 def test_add_water_well_409_bad_group_id(location):
     bad_group_id = 9999


### PR DESCRIPTION
## Problem

  Creating a well via the API with `measuring_point_height` and `measuring_point_description` fails with:
  AttributeError: property 'measuring_point_height' of 'Thing' object has no setter

  This bug was latent in the codebase but only surfaced when API endpoints were called with these fields in the payload.

  ## Root Cause

  `measuring_point_height` and `measuring_point_description` are **not database columns** on the `Thing` model. They are `@property` methods that retrieve the current value from the `MeasuringPointHistory` table. Properties without setters
   cannot be assigned during object construction.

  The transfer scripts (`transfers/well_transfer.py`) already handle this correctly by:
  1. Excluding these fields when creating Thing objects (lines 286-294)
  2. Creating separate `MeasuringPointHistory` records after Thing creation (lines 371-378)

  However, the API service layer (`services/thing_helper.py`) was not following this pattern.

  ## Solution

  Updated `add_thing()` in `services/thing_helper.py` to:
  1. Extract `measuring_point_height` and `measuring_point_description` from data dict before Thing creation
  2. Create the Thing without these fields
  3. After flushing Thing, create a separate `MeasuringPointHistory` record with the extracted values

  **Changes:**
  - Added imports: `datetime`, `ZoneInfo`, `MeasuringPointHistory`
  - Modified `add_thing()` to handle measuring point fields separately (lines 166-190)

  ## Testing

  Added test `test_add_water_well_with_measuring_point()` that:
  - ✅ Reproduces the bug (fails before fix)
  - ✅ Verifies the fix (passes after fix)
  - ✅ Confirms measuring point data is correctly stored and retrieved

  Verified no regressions:
  - ✅ `test_validate_hole_depth_well_depth`
  - ✅ `test_validate_mp_height_hole_depth`
  - ✅ `test_add_well_screen`

  ## Impact

  - **Scope:** API endpoints for creating wells (springs don't have measuring points)
  - **Behavior:** Wells can now be created via API with measuring point data
  - **Consistency:** API service layer now matches transfer script pattern
  - **Breaking changes:** None - this fixes broken functionality

  ## Related

  This bug was discovered during work on [legacy date field migration], (https://github.com/DataIntegrationGroup/NMSampleLocations/pull/264) but is independent of that feature and should be fixed on `main` first.
