### PR TITLE
fix: specify database name in healthcheck for postgres service in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 2s
       timeout: 5s
       retries: 20


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- If the database name is not specified it tries to connect to a database called **user**, which prevents the healthcheck from completing correctly, which causes problems down the line

### **How**
_Implementation summary - the following was changed / added / removed:_
- specify `-d ${POSTGRES_DB}` in the health check

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Use bullet points here
