### PR TITLE
NO TICKET: /geospatial refactor

### DIFF
--- a/api/geospatial.py
+++ b/api/geospatial.py
@@ -101,9 +101,13 @@ def get_feature_collection(
 
     things = get_thing_features(session, thing_type, group)
 
-    def make_feature_dict(thing, geometry, elevation, *other):
-        geometry = json.loads(geometry)
-        geometry["coordinates"].append(elevation)
+    def make_feature_dict(thing):
+        current_location = thing.current_location
+        x = current_location.latlon[1]
+        y = current_location.latlon[0]
+        elevation = current_location.elevation
+        coordinates = [x, y, elevation]
+
         return {
             "type": "Feature",
             "properties": {
@@ -112,10 +116,13 @@ def get_feature_collection(
                 "name": thing.name,
                 "group": group,
             },
-            "geometry": geometry,
+            "geometry": {
+                "type": "Point",
+                "coordinates": coordinates,
+            },
         }
 
-    features = [make_feature_dict(*item) for item in things]
+    features = [make_feature_dict(thing) for thing in things]
 
     return {
         "type": "FeatureCollection",

--- a/services/geospatial_helper.py
+++ b/services/geospatial_helper.py
@@ -20,55 +20,18 @@ from shapely.io import from_geojson
 import constants
 from db.thing import Thing
 from db.group import GroupThingAssociation, Group
-from db.location import Location, LocationThingAssociation
-from geoalchemy2.functions import ST_GeomFromText, ST_Within, ST_AsGeoJSON
+from db.location import Location
+from geoalchemy2.functions import ST_GeomFromText, ST_Within
 from geoalchemy2.shape import to_shape
 from shapely.wkt import loads as wkt_loads
-from sqlalchemy import Select, select
-from sqlalchemy.orm import aliased
-from sqlalchemy import func
+from sqlalchemy import Select
 
 
 def get_thing_features(
     session, thing_type: list | str | None, group: str | int | None
 ) -> list:
-    # sql = (
-    #     select(Thing, ST_AsGeoJSON(Location.point).label("geojson"))
-    #     .join(LocationThingAssociation, Thing.id == LocationThingAssociation.thing_id)
-    #     .join(Location, LocationThingAssociation.location_id == Location.id)
-    # )
 
-    # selection_args = [Thing, ST_AsGeoJSON(Location.point).label("geojson")]
-    # if thing_type == "well":
-    #     selection_args.append(WellThing)
-    # elif thing_type == "spring":
-    #     selection_args.append(SpringThing)
-
-    # Subquery: get the latest association for each thing (optionally only active)
-    lta_alias = aliased(LocationThingAssociation)
-
-    latest_assoc = (
-        select(
-            LocationThingAssociation.thing_id,
-            func.max(LocationThingAssociation.effective_start).label("max_start"),
-        )
-        .where(
-            LocationThingAssociation.effective_end == None
-        )  # Only active, remove if you want most recent regardless of end
-        .group_by(LocationThingAssociation.thing_id)
-        .subquery()
-    )
-
-    sql = (
-        select(Thing, ST_AsGeoJSON(Location.point).label("geojson"), Location.elevation)
-        .join(lta_alias, Thing.id == lta_alias.thing_id)
-        .join(Location, lta_alias.location_id == Location.id)
-        .join(
-            latest_assoc,
-            (latest_assoc.c.thing_id == lta_alias.thing_id)
-            & (latest_assoc.c.max_start == lta_alias.effective_start),
-        )
-    )
+    sql = session.query(Thing)
 
     if thing_type:
         if isinstance(thing_type, str):
@@ -88,7 +51,7 @@ def get_thing_features(
             sql = sql.where(Group.id == group)
 
     # unique needs to be invoked to prevent duplicates from eager loading
-    return session.execute(sql).unique().all()
+    return sql.distinct().all()
 
 
 def create_shapefile(things: list, filename: str = "things.shp") -> None:
@@ -97,7 +60,9 @@ def create_shapefile(things: list, filename: str = "things.shp") -> None:
         shp.field("id", "L")
         shp.field("name", "C")
 
-        for thing, point, elevation in things:
+        for thing in things:
+            point = thing.current_location.point
+            elevation = thing.current_location.elevation
             # Assume loc.point is WKT or a Shapely geometry or GeoJSON
             if isinstance(point, str):
                 try:


### PR DESCRIPTION
Only querying the thing object for geospatial should speed up the process because fewer queries/subqueries need to occur. Since eager loading is used to get the current location, the location data is already available on the thing object.

<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- The `/geospatial` endpoint has been too slow to load the map in Ocotillo

### **How**
_Implementation summary - the following was changed / added / removed:_
- To attempt to fix this speed issue I only query the `thing` table. Since the related tables are eagerly loaded getting the `current_location` and then making a GeoJSON FeatureClass should avoid the N+1 error. Previously subqueries were used, which could adversely effect the performance of the API.
  - We may want to consider a larger refactor of the API where we remove all eager loading and then for each endpoint we use `selectin` or `joinedload` to eagerly load the tables/relationships we want. This will, however, take a lot more time to implement everywhere. So, this may just be a temporary solution until we do that larger refactor.

### **Pros/Cons**
_Any special considerations, workarounds, or follow-up work to note?_
- Pros
  - This is a simple implementation that is easy to understand and maintain.
  - With eager loading N+1 problems should be avoided.
- Cons
  - A _bunch_ of related tables are eagerly loaded when the `thing` table is queried. This can reduce the performance of the API.