### PR TITLE
BDMS 414: updates to the contact response for searches

### DIFF
--- a/api/search.py
+++ b/api/search.py
@@ -26,6 +26,7 @@ from db import (
     Email,
     Phone,
     Address,
+    ThingContactAssociation,
     Thing,
     WellCasingMaterial,
     WellPurpose,
@@ -47,7 +48,18 @@ def _get_contact_results(session: Session, q: str, limit: int) -> list[dict]:
     )
 
     query = search(
-        select(Contact).outerjoin(Email).outerjoin(Phone).outerjoin(Address),
+        select(Contact)
+        .outerjoin(Email)
+        .outerjoin(Phone)
+        .outerjoin(Address)
+        .options(
+            selectinload(Contact.emails),
+            selectinload(Contact.phones),
+            selectinload(Contact.addresses),
+            selectinload(Contact.thing_associations).selectinload(
+                ThingContactAssociation.thing
+            ),
+        ),
         q,
         vector=vector,
         limit=limit,
@@ -61,6 +73,10 @@ def _get_contact_results(session: Session, q: str, limit: int) -> list[dict]:
                 "email": [e.email for e in c.emails],
                 "phone": [p.phone_number for p in c.phones],
                 "address": [a.address_line_1 for a in c.addresses],
+                "things": [
+                    {"label": t.name, "id": t.id, "thing_type": t.thing_type}
+                    for t in c.things
+                ],
                 "id": c.id,
             },
         }

--- a/api/search.py
+++ b/api/search.py
@@ -61,8 +61,7 @@ def _get_contact_results(session: Session, q: str, limit: int) -> list[dict]:
                 "email": [e.email for e in c.emails],
                 "phone": [p.phone_number for p in c.phones],
                 "address": [a.address_line_1 for a in c.addresses],
-                # 'address': c.address,
-                # 'location_id': c.location_id
+                "id": c.id,
             },
         }
         for c in contacts

--- a/api/search.py
+++ b/api/search.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter
 from fastapi_pagination import paginate
 from fastapi_pagination.utils import disable_installed_extensions_check
 from sqlalchemy import select, func, text
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from api.pagination import CustomPage
 from core.dependencies import session_dependency, viewer_dependency
@@ -80,7 +80,11 @@ def _get_thing_results(session: Session, q: str, limit: int) -> list[dict]:
         select(Thing)
         .outerjoin(WellCasingMaterial)
         .outerjoin(WellPurpose)
-        .where(Thing.thing_type == "water well"),
+        .where(Thing.thing_type == "water well")
+        .options(
+            selectinload(Thing.well_casing_materials),
+            selectinload(Thing.well_purposes),
+        ),
         q,
         vector=well_vector,
         limit=limit,
@@ -116,7 +120,7 @@ def _get_thing_results(session: Session, q: str, limit: int) -> list[dict]:
             "Wells",
             thing,
             {
-                "well_purpose": thing.well_purpose,
+                "well_purposes": [wp.purpose for wp in thing.well_purposes],
                 "well_depth": thing.well_depth,
                 "hole_depth": thing.hole_depth,
             },

--- a/db/thing.py
+++ b/db/thing.py
@@ -100,10 +100,6 @@ class Thing(
         info={"unit": "feet below ground surface"},
         comment="Depth of the drilled hole, from ground surface to the bottom of the borehole (in feet).",
     )
-    well_purpose: Mapped[str] = lexicon_term(
-        nullable=True,
-        comment="A controlled vocabulary field defining the primary function of the well (e.g., 'Monitoring', 'Irrigation', 'Domestic', 'Livestock', 'Remediation').",
-    )
     well_casing_diameter: Mapped[float] = mapped_column(
         Float,
         nullable=True,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -48,6 +48,20 @@ def test_search_api(water_well_thing, spring_thing, contact):
     assert isinstance(items, list)
     assert len(items) == 3
 
+    # Check the contacts returned
+    contact_items = [item for item in items if item["group"] == "Contacts"]
+    assert len(contact_items) == 1
+    contact_item = contact_items[0]
+    assert contact_item["label"] == contact.name
+    assert contact_item["properties"]["id"] == contact.id
+    assert contact_item["properties"]["things"] == [
+        {
+            "label": water_well_thing.name,
+            "id": water_well_thing.id,
+            "thing_type": water_well_thing.thing_type,
+        },
+    ]
+
 
 @pytest.mark.skip(reason="This test is not working .")
 def test_search_api2():
@@ -75,7 +89,6 @@ def test_search_contact(contact):
 
         queried_contact = session.scalars(query).first()
         assert queried_contact is not None
-        assert queried_contact.id == contact.id
 
 
 def test_search_contact_no_results(contact):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -75,6 +75,7 @@ def test_search_contact(contact):
 
         queried_contact = session.scalars(query).first()
         assert queried_contact is not None
+        assert queried_contact.id == contact.id
 
 
 def test_search_contact_no_results(contact):


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- The frontend 's needs the contact's `id` to allow the user to click on the contact and navigate immediately to the contact's detail page
- The frontend intends to display the associated things for a contact when it is searched

### **How**
_Implementation summary - the following was changed / added / removed:_
- Added the contact's `id` to its `properties` field
- Added the associated things to its `properties` field. Because the `thing_type` is unknown until they have been retrieved the only fields returned in the array of things are:
  - the `name` (in the `label` field to correspond with how the names are returned elsewhere)
  - the `id`
  - the `thing_type`

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- When the `thing` model was refactored a while ago to allow multiple well purposes we forgot to update the `/search` endpoint. To fix this I removed `well_purpose` from the search's `well_response` and now return a field called `well_purposes` that evaluates to a list of purposes (i.e. a list of one or more strings)
  - e.g. `"well_purposes": ["Domestic", "Irrigation", "Observation"]` or `"well_purposes": ["Open, unequipped well"]`
- eager loading is used to get a contact's emails, phones, addresses, and things since it's unknown how many will be returned, and since they are used in every response from the search query