### PR TITLE
[NO TICKET] Update seeding of the Thing table to swap construction_notes for driller_name

### DIFF
--- a/transfers/seed.py
+++ b/transfers/seed.py
@@ -7,34 +7,35 @@ Run with:
 
 import random
 from datetime import datetime, timedelta, timezone
+
 from faker import Faker
-from db.engine import session_ctx
-from sqlalchemy import select
 from geoalchemy2.elements import WKTElement
+from sqlalchemy import select
 
 # Core models
-from db.contact import Contact, ThingContactAssociation, Email, Phone, Address
-from db.location import Location, LocationThingAssociation
-from db.thing import (
-    Thing,
-    ThingIdLink,
-    WellPurpose,
-    WellCasingMaterial,
-    MonitoringFrequencyHistory,
-)
-from db.measuring_point_history import MeasuringPointHistory
-from db.sensor import Sensor
+from db.analysis_method import AnalysisMethod
+from db.contact import Address, Contact, Email, Phone, ThingContactAssociation
 from db.deployment import Deployment
-from db.field import FieldEvent, FieldActivity, FieldEventParticipant
-from db.sample import Sample
+from db.engine import session_ctx
+from db.field import FieldActivity, FieldEvent, FieldEventParticipant
+from db.lexicon import (
+    LexiconCategory,
+    LexiconTerm,
+    LexiconTermCategoryAssociation,
+)
+from db.location import Location, LocationThingAssociation
+from db.measuring_point_history import MeasuringPointHistory
+from db.notes import Notes
 from db.observation import Observation
 from db.parameter import Parameter
-from db.analysis_method import AnalysisMethod
-from db.notes import Notes
-from db.lexicon import (
-    LexiconTerm,
-    LexiconCategory,
-    LexiconTermCategoryAssociation,
+from db.sample import Sample
+from db.sensor import Sensor
+from db.thing import (
+    MonitoringFrequencyHistory,
+    Thing,
+    ThingIdLink,
+    WellCasingMaterial,
+    WellPurpose,
 )
 
 fake = Faker()
@@ -196,7 +197,7 @@ def seed_all(n: int = 5):
                 first_visit_date=fake.date_between("-2y", "today"),
                 well_depth=random.uniform(50, 500),
                 hole_depth=random.uniform(50, 500),
-                well_construction_notes=fake.sentence(),
+                well_driller_name=fake.name(),
                 well_casing_diameter=random.uniform(4, 8),
                 well_casing_depth=random.uniform(10, 50),
                 release_status="public",


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem/context:_
- This change was breaking the frontend's CI testings

### **How**
_Implementation summary - the following was changed/added/removed:_
- swaped construction_notes for driller_name in Thing row creation

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- None
