### PR TITLE
BDMS 389: measuring notes refactor

### DIFF
--- a/core/lexicon.json
+++ b/core/lexicon.json
@@ -1168,7 +1168,7 @@
     {"categories": ["note_type"], "term": "Historical", "definition": "Historical information or context about the well or location."},
     {"categories": ["note_type"], "term": "General", "definition": "Other types of notes that do not fit into the predefined categories."},
     {"categories": ["note_type"], "term": "Water", "definition": "Water bearing zone information and other info from ose reports"},
-    {"categories": ["note_type"], "term": "Measuring", "definition": "Notes about measuring/visiting the well, on Access form"},
+    {"categories": ["note_type"], "term": "Sampling Procedure", "definition": "Notes about sampling procedures for all sample types, like water levels and water chemistry"},
     {"categories": ["note_type"], "term": "Coordinate", "definition": "Notes about a location's coordinates"},
     {"categories": ["well_pump_type"], "term": "Submersible", "definition": "Submersible"},
     {"categories": ["well_pump_type"], "term": "Jet", "definition": "Jet Pump"},

--- a/db/thing.py
+++ b/db/thing.py
@@ -361,8 +361,8 @@ class Thing(
         return self._get_notes("General")
 
     @property
-    def measuring_notes(self):
-        return self._get_notes("Measuring")
+    def sampling_procedure_notes(self):
+        return self._get_notes("Sampling Procedure")
 
     @property
     def construction_notes(self):

--- a/schemas/thing.py
+++ b/schemas/thing.py
@@ -244,7 +244,7 @@ class WellResponse(BaseThingResponse):
     measuring_point_description: str | None
     aquifers: list[dict] = []
     water_notes: list[NoteResponse] | None = None
-    measuring_notes: list[NoteResponse] | None = None
+    sampling_procedure_notes: list[NoteResponse] | None = None
 
     construction_notes: list[NoteResponse] | None = None
     permissions: list[PermissionHistoryResponse]

--- a/schemas/thing.py
+++ b/schemas/thing.py
@@ -196,7 +196,8 @@ class BaseThingResponse(BaseResponseModel):
     monitoring_status: str | None
     links: list[ThingIdLinkResponse] = Field(default=[], alias="alternate_ids")
     monitoring_frequencies: list[MonitoringFrequencyResponse] = []
-    general_notes: list[NoteResponse] | None = None
+    general_notes: list[NoteResponse] = []
+    sampling_procedure_notes: list[NoteResponse] = []
 
     @field_validator("monitoring_frequencies", mode="before")
     def remove_records_with_end_date(cls, monitoring_frequencies):
@@ -243,10 +244,8 @@ class WellResponse(BaseThingResponse):
     measuring_point_height_unit: str = "ft"
     measuring_point_description: str | None
     aquifers: list[dict] = []
-    water_notes: list[NoteResponse] | None = None
-    sampling_procedure_notes: list[NoteResponse] | None = None
-
-    construction_notes: list[NoteResponse] | None = None
+    water_notes: list[NoteResponse] = []
+    construction_notes: list[NoteResponse] = []
     permissions: list[PermissionHistoryResponse]
     formation_completion_code: FormationCode | None
 

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -115,7 +115,7 @@ def add_well(context, session, location, name_num):
     for nt, c in (
         ("General", "well notes"),
         ("Water", "water notes"),
-        ("Measuring", "measuring notes"),
+        ("Sampling Procedure", "sampling procedure notes"),
         ("Construction", "construction notes"),
     ):
         n = well.add_note(c, nt)

--- a/tests/features/steps/well-notes.py
+++ b/tests/features/steps/well-notes.py
@@ -63,13 +63,17 @@ def step_impl(context):
 
 
 @then(
-    "the response should include measuring notes (notes about measuring/visiting the well, on Access form)"
+    "the response should include sampling procedure notes (notes about sampling procedures for all sample types, like water levels and water chemistry)"
 )
 def step_impl(context):
     data = context.response.json()
-    assert "measuring_notes" in data, "Response does not include measuring notes"
-    assert data["measuring_notes"] is not None, "Measuring notes is null"
-    context.notes["measuring"] = data["measuring_notes"]
+    assert (
+        "sampling_procedure_notes" in data
+    ), "Response does not include sampling procedure notes"
+    assert (
+        data["sampling_procedure_notes"] is not None
+    ), "Sampling Procedure notes is null"
+    context.notes["sampling_procedure"] = data["sampling_procedure_notes"]
 
 
 @then(

--- a/tests/features/well-notes.feature
+++ b/tests/features/well-notes.feature
@@ -17,7 +17,7 @@ Feature: Retrieve well notes by well ID
     And the response should include location notes (i.e. driving directions and geographic well location notes)
     And the response should include construction notes (i.e. pump notes and other construction notes)
     And the response should include general well notes (catch all notes field)
-    And the response should include measuring notes (notes about measuring/visiting the well, on Access form)
+    And the response should include sampling procedure notes (notes about sampling procedures for all sample types, like water levels and water chemistry)
     And the response should include water notes (i.e. water bearing zone information and other info from ose reports)
     And the notes should be a non-empty string
 


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- **well-inventory-csv.feature** has two fields to store notes about sampling scenario (water chemistry) and measurements (water levels). These need to be stored in the poymorphic notes table, but it was unclear where they should be stored. After discussions with @ksmuczynski and @chasetmartin we thought it'd be best for them to be stored as the same note type. We landed on the term `Sampling Procedure` as one that could encapsulate all sampling/measuring procedures, like water chemistry, water levels, geothermal, field parameters, etc

### **How**
_Implementation summary - the following was changed / added / removed:_
- `Measuring` was changed to `Sampling Procedure`, which is where these notes will be stored. Other procedures, such as measuring field parameters, can also be stored here.


### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- This work does not effect the data transfer since no `Measuring` notes are being transferred. 
- This PR is being opened into staging instead of `well-inventory-csv` to keep this refactor separate from its implementation. If/once it is approved I'll then merge that into `well-inventory-csv` and make the requisite updates
- @TylerAdamMartinez this should be a pretty minor change for the frontend. The biggest change is that the field in the `WellResponse` was changed from `measuring_notes` to `sampling_procedure` notes. We did talk about how AMP often uses `sampling` to refer to water chemistry sampling and `measuring` to refer to water level measurements. Perhaps the frontend can use a neutral term? Or is this a cultural shift that should occur at AMP?
