### PR TITLE
BDMS 389: add notes to contact

### DIFF
--- a/core/enums.py
+++ b/core/enums.py
@@ -80,4 +80,5 @@ AquiferType: type[Enum] = build_enum_from_lexicon_category("aquifer_type")
 GeographicScale: type[Enum] = build_enum_from_lexicon_category("geographic_scale")
 Lithology: type[Enum] = build_enum_from_lexicon_category("lithology")
 FormationCode: type[Enum] = build_enum_from_lexicon_category("formation_code")
+NoteType: type[Enum] = build_enum_from_lexicon_category("note_type")
 # ============= EOF =============================================

--- a/core/lexicon.json
+++ b/core/lexicon.json
@@ -1170,6 +1170,7 @@
     {"categories": ["note_type"], "term": "Water", "definition": "Water bearing zone information and other info from ose reports"},
     {"categories": ["note_type"], "term": "Measuring", "definition": "Notes about measuring/visiting the well, on Access form"},
     {"categories": ["note_type"], "term": "Coordinate", "definition": "Notes about a location's coordinates"},
+    {"categories": ["note_type"], "term": "Communication", "definition": "Notes about communication preferences/requests for a contact"},
     {"categories": ["well_pump_type"], "term": "Submersible", "definition": "Submersible"},
     {"categories": ["well_pump_type"], "term": "Jet", "definition": "Jet Pump"},
     {"categories": ["well_pump_type"], "term": "Line Shaft", "definition": "Line Shaft"},

--- a/db/contact.py
+++ b/db/contact.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import relationship, Mapped, mapped_column, declared_attr
 from sqlalchemy_utils import TSVectorType
 
 from db.base import Base, AutoBaseMixin, ReleaseMixin, lexicon_term
+from db.notes import NotesMixin
 
 if TYPE_CHECKING:
     from db.field import FieldEventParticipant, FieldEvent
@@ -45,7 +46,7 @@ class ThingContactAssociation(Base, AutoBaseMixin):
     )
 
 
-class Contact(Base, AutoBaseMixin, ReleaseMixin):
+class Contact(Base, AutoBaseMixin, ReleaseMixin, NotesMixin):
     name: Mapped[str] = mapped_column(String(100), nullable=True)
     organization: Mapped[str] = lexicon_term(nullable=True)
     role: Mapped[str] = lexicon_term(nullable=False)
@@ -123,6 +124,14 @@ class Contact(Base, AutoBaseMixin, ReleaseMixin):
     __table_args__ = (
         UniqueConstraint("name", "organization", name="uq_contact_name_organization"),
     )
+
+    @property
+    def communication_notes(self):
+        return self._get_notes("Communication")
+
+    @property
+    def general_notes(self):
+        return self._get_notes("General")
 
 
 class IncompleteNMAPhone(Base, AutoBaseMixin):

--- a/schemas/contact.py
+++ b/schemas/contact.py
@@ -22,6 +22,7 @@ from pydantic import field_validator, BaseModel, model_validator
 
 from core.enums import Role, ContactType, PhoneType, EmailType, AddressType
 from schemas import BaseResponseModel, BaseCreateModel, BaseUpdateModel
+from schemas.notes import CreateNote, NoteResponse
 
 
 # -------- VALIDATORS ----------
@@ -157,6 +158,7 @@ class CreateContact(BaseCreateModel, ValidateContact):
     emails: list[CreateEmail] | None = None
     phones: list[CreatePhone] | None = None
     addresses: list[CreateAddress] | None = None
+    notes: list[CreateNote] | None = None
 
 
 # -------- RESPONSE ----------
@@ -221,6 +223,8 @@ class ContactResponse(BaseResponseModel):
     phones: List[PhoneResponse] = []
     addresses: List[AddressResponse] = []
     things: List[ThingResponseForContact] = []
+    communication_notes: List[NoteResponse] = []
+    general_notes: List[NoteResponse] = []
 
     @field_validator("incomplete_nma_phones", mode="before")
     def make_incomplete_nma_phone_str(cls, v: list) -> list:

--- a/schemas/notes.py
+++ b/schemas/notes.py
@@ -2,6 +2,9 @@
 Pydantic models for the Notes table.
 """
 
+from core.enums import NoteType
+
+from pydantic import BaseModel
 from schemas import BaseCreateModel, BaseUpdateModel, BaseResponseModel
 
 # -------- BASE SCHEMA: ----------
@@ -10,8 +13,8 @@ Defines the core, shared attributes of a Note for reuse.
 """
 
 
-class BaseNote:
-    note_type: str
+class BaseNote(BaseModel):
+    note_type: NoteType
     content: str
 
 

--- a/services/contact_helper.py
+++ b/services/contact_helper.py
@@ -62,6 +62,7 @@ def add_contact(session: Session, data: CreateContact | dict, user: dict) -> Con
     phone_data = data.pop("phones", [])
     address_data = data.pop("addresses", [])
     thing_id = data.pop("thing_id", None)
+    notes_data = data.pop("notes", None)
     contact_data = data
 
     """
@@ -104,12 +105,21 @@ def add_contact(session: Session, data: CreateContact | dict, user: dict) -> Con
         audit_add(user, location_contact_association)
 
         session.add(location_contact_association)
-        # owner_contact_association = OwnerContactAssociation()
-        # owner_contact_association.owner_id = owner.id
-        # owner_contact_association.contact_id = contact.id
-        # session.add(owner_contact_association)
+
         session.flush()
         session.commit()
+
+        if notes_data is not None:
+            for n in notes_data:
+                note = contact.add_note(n["content"], n["note_type"])
+                session.add(note)
+
+        session.commit()
+        session.refresh(contact)
+
+        for note in contact.notes:
+            session.refresh(note)
+
     except Exception as e:
         session.rollback()
         raise e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def location():
         session.commit()
         session.refresh(loc)
 
-        note = loc.add_note("these are some test notes", "Other")
+        note = loc.add_note("these are some test notes", "General")
         session.add(note)
         session.commit()
         session.refresh(loc)
@@ -355,6 +355,14 @@ def contact(water_well_thing):
         session.add(association)
         session.commit()
         session.refresh(association)
+
+        for content, note_type in [
+            ("Communication note", "Communication"),
+            ("General note", "General"),
+        ]:
+            note = contact.add_note(content, note_type)
+            session.add(note)
+        session.commit()
 
         yield contact
         session.delete(contact)

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -108,6 +108,12 @@ def test_add_contact(spring_thing):
                 "address_type": "Primary",
             }
         ],
+        "notes": [
+            {
+                "note_type": "General",
+                "content": "This is a general note for the contact.",
+            }
+        ],
     }
     response = client.post("/contact", json=payload)
     data = response.json()
@@ -157,6 +163,12 @@ def test_add_contact(spring_thing):
         data["addresses"][0]["address_type"] == payload["addresses"][0]["address_type"]
     )
     assert data["release_status"] == payload["release_status"]
+
+    assert data["general_notes"][0]["note_type"] == "General"
+    assert (
+        data["general_notes"][0]["content"] == "This is a general note for the contact."
+    )
+    assert len(data["communication_notes"]) == 0
 
     cleanup_post_test(Contact, data["id"])
 
@@ -429,6 +441,11 @@ def test_get_contacts(
     assert data["items"][0]["addresses"][0]["address_type"] == address.address_type
     assert data["items"][0]["addresses"][0]["release_status"] == address.release_status
 
+    assert data["items"][0]["general_notes"][0]["note_type"] == "General"
+    assert data["items"][0]["general_notes"][0]["content"] == "General note"
+    assert data["items"][0]["communication_notes"][0]["note_type"] == "Communication"
+    assert data["items"][0]["communication_notes"][0]["content"] == "Communication note"
+
 
 def test_get_contacts_by_thing_id(contact, second_contact, water_well_thing):
     response = client.get(f"/contact?thing_id={water_well_thing.id}")
@@ -494,6 +511,11 @@ def test_get_contact_by_id(
     assert data["addresses"][0]["country"] == address.country
     assert data["addresses"][0]["address_type"] == address.address_type
     assert data["addresses"][0]["release_status"] == address.release_status
+
+    assert data["general_notes"][0]["note_type"] == "General"
+    assert data["general_notes"][0]["content"] == "General note"
+    assert data["communication_notes"][0]["note_type"] == "Communication"
+    assert data["communication_notes"][0]["content"] == "Communication note"
 
 
 def test_get_contact_by_id_404_not_found(contact):

--- a/transfers/contact_transfer.py
+++ b/transfers/contact_transfer.py
@@ -365,8 +365,7 @@ def _make_contact_and_assoc(session, data, thing, added):
         from schemas.contact import CreateContact
 
         contact = CreateContact(**data)
-        contact_data = contact.model_dump()
-        contact_data.pop("thing_id")
+        contact_data = contact.model_dump(exclude=["thing_id", "notes"])
         contact = Contact(**contact_data)
         session.add(contact)
 


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- **well-inventory-csv.feature** requires notes to be added to the `Contact` model

### **How**
_Implementation summary - the following was changed / added / removed:_
- Added the `NotesMixin` to the `Contact` model
- Updated `add_contact` to includes notes.
  - The notes need to be refreshed after they have been added so that the notes associated with the returned `contact` object have the correct `note_type`. If not refreshed their `note_types` will be members of the enum, not strings.
- Updated tests
- Added `Communication` as a `note_type` since that is specified in the feature file
- 

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Updated `note_type` in `CreateNote` and `NoteRersponse` schemas to be typed to the `NoteType` enum, which is made from the lexicon
- This PR is being opened into staging instead of well-inventory-csv to keep this refactor separate from its implementation. If/once it is approved I'll then merge that into well-inventory-csv and make the requisite updates
