### PR TITLE
NO TICKET: update note type from 'Other' to 'General'

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def location():
         session.commit()
         session.refresh(loc)
 
-        note = loc.add_note("these are some test notes", "Other")
+        note = loc.add_note("these are some test notes", "General")
         session.add(note)
         session.commit()
         session.refresh(loc)

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -142,7 +142,7 @@ def test_patch_location_404_not_found(location):
     location_notes_patch = "patched notes"
     response = client.patch(
         f"/location/{bad_location_id}",
-        json={"notes": [{"content": location_notes_patch, "note_type": "Other"}]},
+        json={"notes": [{"content": location_notes_patch, "note_type": "General"}]},
     )
     data = response.json()
     assert response.status_code == 404

--- a/transfers/well_transfer.py
+++ b/transfers/well_transfer.py
@@ -313,7 +313,9 @@ class WellTransferer(Transferer):
                 measuring_point_height=mpheight,
                 measuring_point_description=mpheight_description,
                 notes=(
-                    [{"content": row.Notes, "note_type": "Other"}] if row.Notes else []
+                    [{"content": row.Notes, "note_type": "General"}]
+                    if row.Notes
+                    else []
                 ),
                 well_completion_date=row.CompletionDate,
                 well_driller_name=row.DrillerName,


### PR DESCRIPTION
These instances were missed when 'Other' was refactored to 'General'

<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- When notes of type `Other` were refactored to `General` I missed some places in the code that needed refactoring. This PR fixes those few locations.

### **How**
_Implementation summary - the following was changed / added / removed:_
- Use `note_type` of `General` instead of `Other`

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Use bullet points here
