### PR TITLE
BDMS 389: fixes

### DIFF
--- a/api/well_inventory.py
+++ b/api/well_inventory.py
@@ -87,7 +87,7 @@ def _make_contact(model: WellInventoryRow, well: Thing, idx) -> dict:
     notes = []
     for content, note_type in (
         (model.result_communication_preference, "Communication"),
-        (model.contact_special_instructions, "General"),
+        (model.contact_special_requests_notes, "General"),
     ):
         if content is not None:
             notes.append({"content": content, "note_type": note_type})
@@ -546,7 +546,6 @@ def _add_csv_row(session: Session, group: Group, model: WellInventoryRow, user) 
     )
     well_data = data.model_dump(
         exclude=[
-            "well_purposes",
             "well_casing_materials",
         ]
     )

--- a/api/well_inventory.py
+++ b/api/well_inventory.py
@@ -509,7 +509,7 @@ def _add_csv_row(session: Session, group: Group, model: WellInventoryRow, user) 
         (model.special_requests, "General"),
         (model.well_measuring_notes, "Sampling Procedure"),
         (model.sampling_scenario_notes, "Sampling Procedure"),
-        (historic_depth_note, "Historic"),
+        (historic_depth_note, "Historical"),
     ):
         if note_content is not None:
             well_notes.append({"content": note_content, "note_type": note_type})

--- a/services/contact_helper.py
+++ b/services/contact_helper.py
@@ -98,13 +98,12 @@ def add_contact(session: Session, data: CreateContact | dict, user: dict) -> Con
         session.flush()
         session.refresh(contact)
         if thing_id is not None:
-            location_contact_association = ThingContactAssociation()
-            location_contact_association.thing_id = thing_id
-            location_contact_association.contact_id = contact.id
+            thing_contact_association = ThingContactAssociation()
+            thing_contact_association.thing_id = thing_id
+            thing_contact_association.contact_id = contact.id
 
-            audit_add(user, location_contact_association)
-
-        session.add(location_contact_association)
+            audit_add(user, thing_contact_association)
+            session.add(thing_contact_association)
 
         session.flush()
         session.commit()


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_

There are some minor errors in the implementations/updates I made recently. This PR is to fix those errors.
- The correct field needs to be used for contact special request notes
- A `ThingContactAssociation` should only be added if the table object is created
- `well_purposes` should be kept in the data passed to `add_thing`
- `note_type` is `Historical` not `Historic`

### **How**
_Implementation summary - the following was changed / added / removed:_
- The contact special requests field is named `contact_special_requests_notes` not `contact_special_instructions`
- Adding a `ThingContactAssociation` record was moved into the `if` statement
- `well_purposes` was removed from the excluded fields in the model dump for well data

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- I updated the name in `add_contact` to reflect the name of the table where a record is being stored
