### PR TITLE
BDMS 389: open and datalogger suitability status implementation for well inventory csv

### DIFF
--- a/api/well_inventory.py
+++ b/api/well_inventory.py
@@ -558,6 +558,7 @@ def _add_csv_row(session: Session, group: Group, model: WellInventoryRow, user) 
         well_pump_type=model.well_pump_type,
         well_pump_depth=model.well_pump_depth_ft,
         is_suitable_for_datalogger=model.datalogger_possible,
+        is_open=model.is_open,
         notes=well_notes,
         well_purposes=well_purposes,
     )

--- a/schemas/thing.py
+++ b/schemas/thing.py
@@ -162,6 +162,7 @@ class CreateWell(CreateBaseThing, ValidateWell):
     well_pump_type: WellPumpType | None = None
     well_pump_depth: float | None = None
     is_suitable_for_datalogger: bool | None
+    is_open: bool | None = None
     formation_completion_code: FormationCode | None = None
 
 

--- a/schemas/well_inventory.py
+++ b/schemas/well_inventory.py
@@ -240,7 +240,7 @@ class WellInventoryRow(BaseModel):
     depth_source: Optional[str] = None
     well_pump_type: Optional[str] = None
     well_pump_depth_ft: OptionalFloat = None
-    is_open: OptionalBool = None  # TODO: needs a home
+    is_open: OptionalBool = None
     datalogger_possible: OptionalBool = None
     casing_diameter_ft: OptionalFloat = None
     measuring_point_description: Optional[str] = None

--- a/services/thing_helper.py
+++ b/services/thing_helper.py
@@ -397,7 +397,6 @@ def add_thing(
         session.rollback()
         raise e
 
-    print("returning thing")
     return thing
 
 

--- a/services/thing_helper.py
+++ b/services/thing_helper.py
@@ -394,7 +394,6 @@ def add_thing(
             session.refresh(note)
 
     except Exception as e:
-        print(e)
         session.rollback()
         raise e
 

--- a/services/thing_helper.py
+++ b/services/thing_helper.py
@@ -38,6 +38,7 @@ from db import (
     DataProvenance,
     ThingIdLink,
     MonitoringFrequencyHistory,
+    StatusHistory,
 )
 
 from services.audit_helper import audit_add
@@ -201,6 +202,8 @@ def add_thing(
     effective_start = data.get("first_visit_date")
     group_id = data.pop("group_id", None)
     monitoring_frequencies = data.pop("monitoring_frequencies", None)
+    datalogger_suitability_status = data.pop("is_suitable_for_datalogger", None)
+    open_status = data.pop("is_open", None)
 
     # ----------
     # END UNIVERSAL THING RELATED TABLES
@@ -297,6 +300,38 @@ def add_thing(
                     audit_add(user, wcm)
                     session.add(wcm)
 
+            if datalogger_suitability_status is not None:
+                if datalogger_suitability_status is True:
+                    status_value = "Datalogger can be installed"
+                else:
+                    status_value = "Datalogger cannot be installed"
+                dlss = StatusHistory(
+                    target_id=thing.id,
+                    target_table="thing",
+                    status_value=status_value,
+                    status_type="Datalogger Suitability Status",
+                    start_date=effective_start,
+                    end_date=None,
+                )
+                audit_add(user, dlss)
+                session.add(dlss)
+
+            if open_status is not None:
+                if open_status is True:
+                    status_value = "Open"
+                else:
+                    status_value = "Closed"
+                os_status = StatusHistory(
+                    target_id=thing.id,
+                    target_table="thing",
+                    status_value=status_value,
+                    status_type="Open Status",
+                    start_date=effective_start,
+                    end_date=None,
+                )
+                audit_add(user, os_status)
+                session.add(os_status)
+
         # ----------
         # END WATER WELL SPECIFIC LOGIC
         # ----------
@@ -359,9 +394,11 @@ def add_thing(
             session.refresh(note)
 
     except Exception as e:
+        print(e)
         session.rollback()
         raise e
 
+    print("returning thing")
     return thing
 
 

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -503,8 +503,6 @@ def before_all(context):
     context.objects = {}
 
     rebuild = True
-    # rebuild = True
-    erase_data = True
     if rebuild:
         erase_and_rebuild_db()
     elif get_bool_env("ERASE_DATA", False):

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -502,6 +502,7 @@ def before_all(context):
     context.objects = {}
 
     rebuild = True
+    erase_data = False
     if rebuild:
         erase_and_rebuild_db()
     elif erase_data:

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -504,7 +504,7 @@ def before_all(context):
 
     rebuild = True
     # rebuild = True
-    erase_data = False
+    erase_data = True
     if rebuild:
         erase_and_rebuild_db()
     elif get_bool_env("ERASE_DATA", False):


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- Two fields from the well inventory csv need to be recorded correctly in the `status_history` table: `is_open` and `datalogger_possible`

### **How**
_Implementation summary - the following was changed / added / removed:_
- If either field is set they get written to the `status_history` table

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- The branch `well-inventory-csv` contains the work done in PR #299. This was approved to go into `staging`, but since it modifies the database models it has not yet been merged. Once that is merged into `staging` the refactoring of putting these fields into the `status_history` table will be in both `staging` and `well-inventory-csv`
- Once this is incorporated into `well-inventory-csv` all well core and additional information will be accounted for. Next is the water levels
