### PR TITLE
NO TICKET: update water level feature field names

### DIFF
--- a/tests/features/water-level-csv.feature
+++ b/tests/features/water-level-csv.feature
@@ -63,8 +63,8 @@ Feature: Bulk upload water level entries from CSV via CLI
     And the CSV includes required fields:
       | required field name   |
       | well_name_point_id    |
-      | measurement_date_time |
-      | sampler               |
+      | water_level_date_time |
+      | measuring_person      |
       | sample_method         |
       | mp_height             |
       | level_status          |
@@ -118,8 +118,8 @@ Feature: Bulk upload water level entries from CSV via CLI
     Examples:
       | required_field        |
       | well_name_point_id    |
-      | measurement_date_time |
-      | sampler               |
+      | water_level_date_time |
+      | measuring_person      |
       | sample_method         |
       | mp_height             |
       | level_status          |
@@ -128,7 +128,7 @@ Feature: Bulk upload water level entries from CSV via CLI
 
   @negative @validation @date_formats @BDMS-TBD
   Scenario: Upload fails due to invalid date formats
-    Given my CSV file contains invalid ISO 8601 date values in the "measurement_date_time" field
+    Given my CSV file contains invalid ISO 8601 date values in the "water_level_date_time" field
     When I run the CLI command:
       """
       oco water-levels bulk-upload --file ./water_levels.csv
@@ -150,7 +150,7 @@ Feature: Bulk upload water level entries from CSV via CLI
 
   @negative @validation @lexicon_values @BDMS-TBD
   Scenario: Upload fails due to invalid lexicon values
-    Given my CSV file contains invalid lexicon values for "sampler", "sample_method", "level_status", or "data_quality"
+    Given my CSV file contains invalid lexicon values for "measuring_person", "sample_method", "level_status", or "data_quality"
     When I run the CLI command:
       """
       oco water-levels bulk-upload --file ./water_levels.csv

--- a/tests/features/water-level-csv.feature
+++ b/tests/features/water-level-csv.feature
@@ -37,7 +37,7 @@ Feature: Bulk upload water level entries from CSV via CLI
       | depth_to_water_ft     |
       | data_quality          |
     And each "well_name_point_id" value matches an existing well
-    And "measurement_date_time" values are valid ISO 8601 timestamps with timezone offsets (e.g. "2025-02-15T10:30:00-08:00")
+    And "water_level_date_time" values are valid ISO 8601 timezone-naive datetime strings (e.g. "2025-02-15T10:30:00")
     And the CSV includes optional fields when available:
       | optional field name |
       | field_staff_2       |
@@ -74,7 +74,9 @@ Feature: Bulk upload water level entries from CSV via CLI
       """
       oco water-levels bulk-upload --file ./water_levels.csv
       """
-    Then the command exits with code 0
+    # assumes users are entering datetimes as Mountain Time becuase well location is restricted to New Mexico
+    Then all datetime objects are assigned the correct Mountain Time timezone offset based on the date value. 
+    And the command exits with code 0
     And all water level entries are imported
     And stderr should be empty
 

--- a/tests/features/water-level-csv.feature
+++ b/tests/features/water-level-csv.feature
@@ -15,7 +15,6 @@ Feature: Bulk upload water level entries from CSV via CLI
 #    And I have a valid CLI configuration for the target environment
 #    And valid lexicon values exist for:
 #      | lexicon category |
-#      | sampler          |
 #      | sample_method    |
 #      | level_status     |
 #      | data_quality     |
@@ -30,8 +29,8 @@ Feature: Bulk upload water level entries from CSV via CLI
       | field_staff           |
       | well_name_point_id    |
       | field_event_date_time |
-      | measurement_date_time |
-      | sampler               |
+      | water_level_date_time |
+      | measuring_person      |
       | sample_method         |
       | mp_height             |
       | level_status          |
@@ -41,7 +40,9 @@ Feature: Bulk upload water level entries from CSV via CLI
     And "measurement_date_time" values are valid ISO 8601 timestamps with timezone offsets (e.g. "2025-02-15T10:30:00-08:00")
     And the CSV includes optional fields when available:
       | optional field name |
-      | water_level_notes  |
+      | field_staff_2       |
+      | field_staff_3       |
+      | water_level_notes   |
     When I run the CLI command:
       """
       oco water-levels bulk-upload --file ./water_levels.csv --output json


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- Add the ability for multiple field staff at field event, just like well inventory, and update the field names for measuring_person and water_level_date_time to match the csv template.
