### PR TITLE
NO TICKET: m to ft fix

### DIFF
--- a/services/util.py
+++ b/services/util.py
@@ -45,25 +45,18 @@ def transform_srid(geometry, source_srid, target_srid):
     return transform(transformer.transform, geometry)
 
 
-def convert_m_to_ft(meters: float | None) -> float | None:
-    """Convert a length from meters to feet."""
-    if meters is None:
-        return None
-    return round(meters * METERS_TO_FEET, 6)
-
-
-def convert_ft_to_m(feet: float | None) -> float | None:
+def convert_ft_to_m(feet: float | None, ndigits: int = 6) -> float | None:
     """Convert a length from feet to meters."""
     if feet is None:
         return None
-    return round(feet / METERS_TO_FEET, 6)
+    return round(feet / METERS_TO_FEET, ndigits)
 
 
-def convert_m_to_ft(meters: float | None) -> float | None:
+def convert_m_to_ft(meters: float | None, ndigits: int = 6) -> float | None:
     """Convert a length from meters to feet."""
     if meters is None:
         return None
-    return round(meters * METERS_TO_FEET, 6)
+    return round(meters * METERS_TO_FEET, ndigits)
 
 
 def get_tiger_data(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,17 @@
+from services.util import convert_ft_to_m, convert_m_to_ft
+
+
+def test_convert_ft_to_m():
+    assert convert_ft_to_m(0) == 0.0
+    assert convert_ft_to_m(3.28084) == 1.0
+    assert convert_ft_to_m(10) == 3.048
+    assert convert_ft_to_m(None) is None
+    assert convert_ft_to_m(10, ndigits=4) == 3.048
+
+
+def test_convert_m_to_ft():
+    assert convert_m_to_ft(0) == 0.0
+    assert convert_m_to_ft(1) == 3.28084
+    assert convert_m_to_ft(3.048) == 10.0
+    assert convert_m_to_ft(None) is None
+    assert convert_m_to_ft(3.048, ndigits=4) == 10.0


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- There were duplicate functions to convert from meters to feet
- The number of digits in the rounding was hardcoded. It is now an argument in the function and defaults to 6, which is what was used previously
- util functions need to be tested

### **How**
_Implementation summary - the following was changed / added / removed:_
- Removed one of the duplicate functions
- Enabled the number of digits in the round function to be set as an argument
- Started a test file for **services/util.py** and added tests for `convert_ft_to_m` and `convert_m_to_ft`

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Use bullet points here
