### PR TITLE
NO TICKET: cascade delete for field_activity in Sample model

### DIFF
--- a/db/sample.py
+++ b/db/sample.py
@@ -47,7 +47,7 @@ class Sample(Base, AutoBaseMixin, ReleaseMixin):
 
     # --- Foreign Key Definitions ---
     field_activity_id: Mapped[int] = mapped_column(
-        ForeignKey("field_activity.id"), nullable=False
+        ForeignKey("field_activity.id", ondelete="CASCADE"), nullable=False
     )
 
     field_event_participant_id: Mapped[str] = mapped_column(


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- a `Sample` record should not exist without `FieldEvent` or `FieldActivity` records.

### **How**
_Implementation summary - the following was changed / added / removed:_
- Added `ondelete="CASCADE"` to the `field_activity_id` foreign key defined in `Sample` model. Deleting a `FieldEvent` cascades to deleting a `FieldActivity`, which cascades to deleting the `Sample`. If just a `FieldActivity` is deleted then the `Sample` will still be deleted.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Use bullet points here
