### PR TITLE
feat: add admin interface for Chemistry Sample Info model

### DIFF
--- a/admin/config.py
+++ b/admin/config.py
@@ -40,7 +40,6 @@ from admin.views import (
     DataProvenanceAdmin,
     FieldEventAdmin,
     FieldActivityAdmin,
-    FieldEventParticipantAdmin,
     ParameterAdmin,
 )
 from db.engine import engine
@@ -62,8 +61,7 @@ from db.notes import Notes
 from db.sample import Sample
 from db.geologic_formation import GeologicFormation
 from db.data_provenance import DataProvenance
-from db.field import FieldEvent, FieldActivity, FieldEventParticipant
-from db.permission_history import PermissionHistory
+from db.field import FieldEvent, FieldActivity
 from db.parameter import Parameter
 
 

--- a/admin/views/__init__.py
+++ b/admin/views/__init__.py
@@ -31,6 +31,7 @@ from admin.views.aquifer_system import AquiferSystemAdmin
 from admin.views.group import GroupAdmin
 from admin.views.notes import NotesAdmin
 from admin.views.sample import SampleAdmin
+from admin.views.chemistry_sampleinfo import ChemistrySampleInfoAdmin
 from admin.views.geologic_formation import GeologicFormationAdmin
 from admin.views.data_provenance import DataProvenanceAdmin
 from admin.views.field import (
@@ -55,6 +56,7 @@ __all__ = [
     "GroupAdmin",
     "NotesAdmin",
     "SampleAdmin",
+    "ChemistrySampleInfoAdmin",
     "GeologicFormationAdmin",
     "DataProvenanceAdmin",
     "FieldEventAdmin",

--- a/admin/views/chemistry_sampleinfo.py
+++ b/admin/views/chemistry_sampleinfo.py
@@ -1,0 +1,140 @@
+# ===============================================================================
+# Copyright 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""
+ChemistrySampleInfoAdmin view for legacy Chemistry_SampleInfo.
+"""
+from admin.views.base import OcotilloModelView
+
+
+class ChemistrySampleInfoAdmin(OcotilloModelView):
+    """
+    Admin view for ChemistrySampleInfo model.
+    """
+
+    # ========== Basic Configuration ==========
+
+    name = "Chemistry Sample Info"
+    label = "Chemistry Sample Info"
+    icon = "fa fa-flask"
+
+    # ========== List View ==========
+
+    column_list = [
+        "object_id",
+        "sample_point_id",
+        "sample_pt_id",
+        "wclab_id",
+        "collection_date",
+        "sample_type",
+        "data_source",
+        "data_quality",
+        "public_release",
+    ]
+
+    column_sortable_list = [
+        "object_id",
+        "sample_point_id",
+        "sample_pt_id",
+        "wclab_id",
+        "collection_date",
+        "sample_type",
+        "data_source",
+        "data_quality",
+        "public_release",
+    ]
+
+    column_default_sort = ("collection_date", True)
+
+    search_fields = [
+        "sample_point_id",
+        "sample_pt_id",
+        "wclab_id",
+        "collected_by",
+        "analyses_agency",
+        "sample_notes",
+    ]
+
+    column_filters = [
+        "collection_date",
+        "sample_type",
+        "sample_material_not_h2o",
+        "water_type",
+        "study_sample",
+        "data_source",
+        "data_quality",
+        "public_release",
+    ]
+
+    can_export = True
+    export_types = ["csv", "excel"]
+
+    page_size = 50
+    page_size_options = [25, 50, 100, 200]
+
+    # ========== Form View ==========
+
+    fields = [
+        "object_id",
+        "sample_point_id",
+        "sample_pt_id",
+        "wclab_id",
+        "collection_date",
+        "collection_method",
+        "collected_by",
+        "analyses_agency",
+        "sample_type",
+        "sample_material_not_h2o",
+        "water_type",
+        "study_sample",
+        "data_source",
+        "data_quality",
+        "public_release",
+        "added_day_to_date",
+        "added_month_day_to_date",
+        "sample_notes",
+    ]
+
+    exclude_fields_from_create = [
+        "object_id",
+    ]
+
+    exclude_fields_from_edit = [
+        "object_id",
+    ]
+
+    labels = {
+        "object_id": "OBJECTID",
+        "sample_point_id": "SamplePointID",
+        "sample_pt_id": "SamplePtID",
+        "wclab_id": "WCLab ID",
+        "collection_date": "Collection Date",
+        "collection_method": "Collection Method",
+        "collected_by": "Collected By",
+        "analyses_agency": "Analyses Agency",
+        "sample_type": "Sample Type",
+        "sample_material_not_h2o": "Sample Material Not H2O",
+        "water_type": "Water Type",
+        "study_sample": "Study Sample",
+        "data_source": "Data Source",
+        "data_quality": "Data Quality",
+        "public_release": "Public Release",
+        "added_day_to_date": "Added Day to Date",
+        "added_month_day_to_date": "Added Month Day to Date",
+        "sample_notes": "Sample Notes",
+    }
+
+
+# ============= EOF =============================================


### PR DESCRIPTION
### Why

This PR addresses the following problem / context:

- Expose legacy Chemistry SampleInfo records for admin review and troubleshooting

### How

Implementation summary - the following was changed / added / removed:

- Added ChemistrySampleInfoAdmin view with list, filters, search, and form fields
- Registered the view in admin setup for the legacy Chemistry SampleInfo model

### Notes

Any special considerations, workarounds, or follow-up work to note?

- This view targets the legacy Chemistry_SampleInfo table and is intended for backfill visibility