### PR TITLE
NO TICKET: make sample_pt_id PK for chemistry_sampleinfo

### DIFF
--- a/alembic/versions/b7d4c6a1b2c3_create_chemistry_sampleinfo.py
+++ b/alembic/versions/b7d4c6a1b2c3_create_chemistry_sampleinfo.py
@@ -10,6 +10,7 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import inspect
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "b7d4c6a1b2c3"
@@ -25,9 +26,14 @@ def upgrade() -> None:
     if not inspector.has_table("NMA_Chemistry_SampleInfo"):
         op.create_table(
             "NMA_Chemistry_SampleInfo",
-            sa.Column("OBJECTID", sa.Integer(), primary_key=True),
+            sa.Column("OBJECTID", sa.Integer(), nullable=True),
             sa.Column("SamplePointID", sa.String(length=50), nullable=True),
-            sa.Column("SamplePtID", sa.String(length=50), nullable=True),
+            sa.Column(
+                "SamplePtID",
+                postgresql.UUID(as_uuid=True),
+                nullable=False,
+                primary_key=True,
+            ),
             sa.Column("WCLab_ID", sa.String(length=50), nullable=True),
             sa.Column("CollectionDate", sa.Date(), nullable=True),
             sa.Column("CollectionMethod", sa.String(length=100), nullable=True),

--- a/db/nma_legacy.py
+++ b/db/nma_legacy.py
@@ -159,9 +159,12 @@ class ChemistrySampleInfo(Base):
 
     __tablename__ = "NMA_Chemistry_SampleInfo"
 
-    object_id: Mapped[int] = mapped_column("OBJECTID", Integer, primary_key=True)
+    sample_pt_id: Mapped[uuid.UUID] = mapped_column(
+        "SamplePtID", UUID(as_uuid=True), nullable=False, primary_key=True
+    )
+
+    object_id: Mapped[int] = mapped_column("OBJECTID", nullable=True)
     sample_point_id: Mapped[Optional[str]] = mapped_column("SamplePointID", String(50))
-    sample_pt_id: Mapped[Optional[str]] = mapped_column("SamplePtID", String(50))
     wclab_id: Mapped[Optional[str]] = mapped_column("WCLab_ID", String(50))
 
     collection_date: Mapped[Optional[date]] = mapped_column("CollectionDate", Date)

--- a/transfers/backfill/chemistry_sampleinfo.py
+++ b/transfers/backfill/chemistry_sampleinfo.py
@@ -60,10 +60,10 @@ class ChemistrySampleInfoBackfill(Transferer):
                 f"Upserting batch {i}-{i+len(chunk)-1} ({len(chunk)} rows) into Chemistry_SampleInfo"
             )
             stmt = insert_stmt.values(chunk).on_conflict_do_update(
-                index_elements=["OBJECTID"],
+                index_elements=["SamplePtID"],
                 set_={
                     "SamplePointID": excluded.SamplePointID,
-                    "SamplePtID": excluded.SamplePtID,
+                    "OBJECTID": excluded.OBJECTID,
                     "WCLab_ID": excluded.WCLab_ID,
                     "CollectionDate": excluded.CollectionDate,
                     "CollectionMethod": excluded.CollectionMethod,


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- `SamplePtID`, not `OBJECTID`, is the primary key in NM_Aquifer

### **How**
_Implementation summary - the following was changed / added / removed:_
- Change the primary key to `sample_pt_id` from `object_id` in the `ChemistrySampleInfo` model
- Update `sample_pt_id` to be a UUID to reflect NM_Aquifer
- Update the index to be `SamplePtID` for the insert statement.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- There have been conversations about adding `id` fields to all legacy tables, but this PR does not address that.
