### PR TITLE
Test database connection should not be overridden by .env

### DIFF
--- a/db/engine.py
+++ b/db/engine.py
@@ -32,8 +32,8 @@ from sqlalchemy.util import await_only
 
 from services.util import get_bool_env
 
-# Load .env file with override=True to ensure .env values take precedence over shell env vars
-load_dotenv(override=True)
+# Load .env file - don't override env vars already set (e.g., by test framework)
+load_dotenv(override=False)
 driver = os.environ.get("DB_DRIVER", "")
 
 


### PR DESCRIPTION
## Summary
- Fix `load_dotenv(override=True)` → `load_dotenv(override=False)` in `db/engine.py`
- Prevents test framework's `POSTGRES_DB=ocotilloapi_test` from being overwritten by `.env` values

Fixes #412

## Problem
Tests were connecting to the dev database instead of the test database because `load_dotenv(override=True)` replaced the environment variables set by the test framework in `tests/__init__.py`.

## Test plan
- [x] All 352 tests pass locally
- [x] Tests correctly use `ocotilloapi_test` database

🤖 Generated with [Claude Code](https://claude.ai/code)