### PR TITLE
[BDMS-492] Create new admin view for the legacy stratigraphy table

### DIFF
--- a/admin/config.py
+++ b/admin/config.py
@@ -48,6 +48,7 @@ from admin.views import (
     FieldActivityAdmin,
     ParameterAdmin,
     SurfaceWaterDataAdmin,
+    StratigraphyAdmin,
 )
 
 from db.engine import engine
@@ -73,6 +74,7 @@ from db.nma_legacy import (
     NMARadionuclides,
     NMAMinorTraceChemistry,
     SurfaceWaterData,
+    Stratigraphy,
 )
 from db.geologic_formation import GeologicFormation
 from db.data_provenance import DataProvenance
@@ -167,6 +169,9 @@ def create_admin(app):
     # Lexicon
     admin.add_view(LexiconTermAdmin(LexiconTerm))
     admin.add_view(LexiconCategoryAdmin(LexiconCategory))
+
+    # Stratigraphy
+    admin.add_view(StratigraphyAdmin(Stratigraphy))
 
     # Future: Add more views here as they are implemented
     # admin.add_view(SampleAdmin)

--- a/admin/views/__init__.py
+++ b/admin/views/__init__.py
@@ -19,59 +19,61 @@ Admin views package for NMSampleLocations.
 Provides MS Access-like interface for CRUD operations on database models.
 """
 
-from admin.views.location import LocationAdmin
-from admin.views.thing import ThingAdmin
-from admin.views.observation import ObservationAdmin
-from admin.views.contact import ContactAdmin
-from admin.views.sensor import SensorAdmin
-from admin.views.deployment import DeploymentAdmin
-from admin.views.lexicon import LexiconTermAdmin, LexiconCategoryAdmin
 from admin.views.asset import AssetAdmin
-from admin.views.aquifer_type import AquiferTypeAdmin
 from admin.views.aquifer_system import AquiferSystemAdmin
-from admin.views.group import GroupAdmin
-from admin.views.notes import NotesAdmin
-from admin.views.sample import SampleAdmin
-from admin.views.hydraulicsdata import HydraulicsDataAdmin
+from admin.views.aquifer_type import AquiferTypeAdmin
 from admin.views.chemistry_sampleinfo import ChemistrySampleInfoAdmin
-from admin.views.radionuclides import RadionuclidesAdmin
-from admin.views.minor_trace_chemistry import MinorTraceChemistryAdmin
-from admin.views.geologic_formation import GeologicFormationAdmin
+from admin.views.contact import ContactAdmin
 from admin.views.data_provenance import DataProvenanceAdmin
-from admin.views.transducer_observation import TransducerObservationAdmin
+from admin.views.deployment import DeploymentAdmin
 from admin.views.field import (
-    FieldEventAdmin,
     FieldActivityAdmin,
+    FieldEventAdmin,
     FieldEventParticipantAdmin,
 )
+from admin.views.geologic_formation import GeologicFormationAdmin
+from admin.views.group import GroupAdmin
+from admin.views.hydraulicsdata import HydraulicsDataAdmin
+from admin.views.lexicon import LexiconCategoryAdmin, LexiconTermAdmin
+from admin.views.location import LocationAdmin
+from admin.views.minor_trace_chemistry import MinorTraceChemistryAdmin
+from admin.views.notes import NotesAdmin
+from admin.views.observation import ObservationAdmin
 from admin.views.parameter import ParameterAdmin
+from admin.views.radionuclides import RadionuclidesAdmin
+from admin.views.sample import SampleAdmin
+from admin.views.sensor import SensorAdmin
+from admin.views.stratigraphy import StratigraphyAdmin
 from admin.views.surface_water import SurfaceWaterDataAdmin
+from admin.views.thing import ThingAdmin
+from admin.views.transducer_observation import TransducerObservationAdmin
 
 __all__ = [
-    "LocationAdmin",
-    "ThingAdmin",
-    "ObservationAdmin",
-    "ContactAdmin",
-    "SensorAdmin",
-    "DeploymentAdmin",
-    "LexiconTermAdmin",
-    "LexiconCategoryAdmin",
     "AssetAdmin",
-    "AquiferTypeAdmin",
     "AquiferSystemAdmin",
-    "GroupAdmin",
-    "NotesAdmin",
-    "SampleAdmin",
-    "HydraulicsDataAdmin",
+    "AquiferTypeAdmin",
     "ChemistrySampleInfoAdmin",
-    "RadionuclidesAdmin",
-    "MinorTraceChemistryAdmin",
-    "GeologicFormationAdmin",
+    "ContactAdmin",
     "DataProvenanceAdmin",
-    "TransducerObservationAdmin",
-    "FieldEventAdmin",
+    "DeploymentAdmin",
     "FieldActivityAdmin",
+    "FieldEventAdmin",
     "FieldEventParticipantAdmin",
+    "GeologicFormationAdmin",
+    "GroupAdmin",
+    "HydraulicsDataAdmin",
+    "LexiconCategoryAdmin",
+    "LexiconTermAdmin",
+    "LocationAdmin",
+    "MinorTraceChemistryAdmin",
+    "NotesAdmin",
+    "ObservationAdmin",
     "ParameterAdmin",
+    "RadionuclidesAdmin",
+    "SampleAdmin",
+    "SensorAdmin",
+    "StratigraphyAdmin",
     "SurfaceWaterDataAdmin",
+    "ThingAdmin",
+    "TransducerObservationAdmin",
 ]

--- a/admin/views/stratigraphy.py
+++ b/admin/views/stratigraphy.py
@@ -1,0 +1,84 @@
+"""
+StratigraphyAdmin view for legacy Chemistry_SampleInfo.
+"""
+
+from admin.views.base import OcotilloModelView
+
+
+class StratigraphyAdmin(OcotilloModelView):
+    """
+    Read-only admin view for Stratigraphy legacy model.
+    """
+
+    # ========== Basic Configuration ==========
+    name = "NMA Stratigraphy"
+    label = "NMA Stratigraphy"
+    icon = "fa fa-layer-group"
+
+    # Pagination
+    page_size = 50
+    page_size_options = [25, 50, 100, 200]
+
+    # ========== List View ==========
+
+    sortable_fields = [
+        "global_id",
+        "object_id",
+        "point_id",
+    ]
+
+    fields_default_sort = [("point_id", False), ("strat_top", False)]
+
+    searchable_fields = [
+        "point_id",
+        "global_id",
+        "unit_identifier",
+        "lithology",
+        "lithologic_modifier",
+        "contributing_unit",
+        "strat_source",
+        "strat_notes",
+    ]
+
+    # ========== Form View ==========
+
+    fields = [
+        "global_id",
+        "well_id",
+        "point_id",
+        "thing_id",
+        "strat_top",
+        "strat_bottom",
+        "unit_identifier",
+        "lithology",
+        "lithologic_modifier",
+        "contributing_unit",
+        "strat_source",
+        "strat_notes",
+        "object_id",
+    ]
+
+    exclude_fields_from_create = [
+        "object_id",
+    ]
+
+    exclude_fields_from_edit = [
+        "object_id",
+    ]
+
+    # ========== Legacy Field Labels ==========
+    field_labels = {
+        "global_id": "GlobalID",
+        "well_id": "WellID",
+        "point_id": "PointID",
+        "thing_id": "ThingID",
+        "strat_top": "StratTop",
+        "strat_bottom": "StratBottom",
+        "unit_identifier": "UnitIdentifier",
+        "lithology": "Lithology",
+        "lithologic_modifier": "LithologicModifier",
+        "contributing_unit": "ContributingUnit",
+        "strat_source": "StratSource",
+        "strat_notes": "StratNotes",
+        "object_id": "OBJECTID",
+    }

--- a/admin/views/stratigraphy.py
+++ b/admin/views/stratigraphy.py
@@ -1,5 +1,5 @@
 """
-StratigraphyAdmin view for legacy Chemistry_SampleInfo.
+StratigraphyAdmin view for legacy stratigraphy.
 """
 
 from admin.views.base import OcotilloModelView


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem/context:_
- Legacy stratigraphy data was not accessible in the admin UI

### **How**
_Implementation summary - the following was changed/added/removed:_
- Added `StratigraphyAdmin` using the shared `OcotilloModelView` base

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- This change assumes the `NMA_Stratigraphy` relation exists in the connected database
