### PR TITLE
[NO TICKET ] Mv guard & logger up before list() to prevent crashes in transfers/profiling.py

### DIFF
--- a/transfers/profiling.py
+++ b/transfers/profiling.py
@@ -20,7 +20,7 @@ import pstats
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Iterable, Any
+from typing import Callable, Iterable, Any, Optional
 
 from services.gcs_helper import get_storage_bucket
 from transfers.logger import logger
@@ -84,13 +84,14 @@ class TransferProfiler:
         return result, artifact
 
 
-def upload_profile_artifacts(artifacts: Iterable[ProfileArtifact]) -> None:
+def upload_profile_artifacts(artifacts: Optional[Iterable[ProfileArtifact]]) -> None:
     """Upload generated profiling artifacts to the configured storage bucket."""
-
-    artifacts = list(artifacts)
     if not artifacts:
         logger.info("No profiling artifacts to upload")
         return
+
+    artifacts = list(artifacts)
+
     bucket = get_storage_bucket()
     for artifact in artifacts:
         for path in (artifact.stats_path, artifact.report_path):


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem/context:_
- `upload_profile_artifacts()` could crash with `TypeError: 'NoneType' object is not iterable` when profiling artifacts were not present.

### **How**
_Implementation summary - the following was changed/added/removed:_
- Updated `upload_profile_artifacts` to accept `Optional[Iterable[ProfileArtifact]]` instead of requiring an iterable
- Added an early-return guard for `None`/empty artifacts and logged a helpful message when there’s nothing to upload.
- Moved `list(artifacts)` conversion to occur only after the `None`/empty check to avoid exceptions.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Please see this PR before merging #420 
