### PR TITLE
BDMS-504 Implement read-only admin view for NMAFieldParameters

### DIFF
--- a/admin/config.py
+++ b/admin/config.py
@@ -50,7 +50,9 @@ from admin.views import (
     SurfaceWaterDataAdmin,
     ThingAdmin,
     TransducerObservationAdmin,
+    FieldParametersAdmin,
 )
+from db import NMA_FieldParameters
 from db.aquifer_system import AquiferSystem
 from db.aquifer_type import AquiferType
 from db.asset import Asset
@@ -154,6 +156,7 @@ def create_admin(app):
 
     # Parameters
     admin.add_view(ParameterAdmin(Parameter))
+    admin.add_view(FieldParametersAdmin(NMA_FieldParameters))
 
     # Geology
     admin.add_view(GeologicFormationAdmin(GeologicFormation))

--- a/admin/views/__init__.py
+++ b/admin/views/__init__.py
@@ -31,6 +31,7 @@ from admin.views.field import (
     FieldEventAdmin,
     FieldEventParticipantAdmin,
 )
+from admin.views.field_parameters import FieldParametersAdmin
 from admin.views.geologic_formation import GeologicFormationAdmin
 from admin.views.group import GroupAdmin
 from admin.views.hydraulicsdata import HydraulicsDataAdmin
@@ -60,6 +61,7 @@ __all__ = [
     "FieldActivityAdmin",
     "FieldEventAdmin",
     "FieldEventParticipantAdmin",
+    "FieldParametersAdmin",
     "GeologicFormationAdmin",
     "GroupAdmin",
     "HydraulicsDataAdmin",

--- a/admin/views/field_parameters.py
+++ b/admin/views/field_parameters.py
@@ -16,6 +16,7 @@
 """
 FieldParametersAdmin view for legacy NMA_FieldParameters.
 """
+from starlette.requests import Request
 
 from admin.views.base import OcotilloModelView
 
@@ -31,9 +32,14 @@ class FieldParametersAdmin(OcotilloModelView):
     label = "NMA Field Parameters"
     icon = "fa fa-tachometer"
 
-    can_create = False
-    can_edit = False
-    can_delete = False
+    def can_create(self, request: Request) -> bool:
+        return False
+
+    def can_edit(self, request: Request) -> bool:
+        return False
+
+    def can_delete(self, request: Request) -> bool:
+        return False
 
     # ========== List View ==========
 

--- a/admin/views/field_parameters.py
+++ b/admin/views/field_parameters.py
@@ -27,8 +27,8 @@ class FieldParametersAdmin(OcotilloModelView):
 
     # ========== Basic Configuration ==========
 
-    name = "Field Parameters"
-    label = "Field Parameters"
+    name = "NMA Field Parameters"
+    label = "NMA Field Parameters"
     icon = "fa fa-tachometer"
 
     can_create = False

--- a/admin/views/field_parameters.py
+++ b/admin/views/field_parameters.py
@@ -44,9 +44,10 @@ class FieldParametersAdmin(OcotilloModelView):
         "field_parameter",
         "sample_value",
         "units",
+        "notes",
+        "object_id",
         "analyses_agency",
         "wc_lab_id",
-        "object_id",
     ]
 
     sortable_fields = [

--- a/admin/views/field_parameters.py
+++ b/admin/views/field_parameters.py
@@ -16,6 +16,7 @@
 """
 FieldParametersAdmin view for legacy NMA_FieldParameters.
 """
+
 from starlette.requests import Request
 
 from admin.views.base import OcotilloModelView


### PR DESCRIPTION
<!--
- BDMS-504 Read-only admin view fore NMAFieldParameters
-->
### **Why**
_This PR addresses the following problem / context:_
  - Expose and manage NMA Field Parameters in the admin UI, including legacy ordering and new notes support
  - Align admin naming/labeling and permissions with expected behavior


### **How**
_Implementation summary - the following was changed / added / removed:_
- Implemented permission methods for the admin view
- Updated name/label for NMA Field Parameters
- Added notes field and reordered fields to match legacy model order
- Added FieldParametersAdmin to the admin view module
- Registered FieldParametersAdmin in the admin configuration


### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- None
