### PR TITLE
BDMS-503: Implement read-only admin view for NMAMajorChemistry

### DIFF
--- a/admin/config.py
+++ b/admin/config.py
@@ -38,6 +38,7 @@ from admin.views import (
     LexiconCategoryAdmin,
     LexiconTermAdmin,
     LocationAdmin,
+    MajorChemistryAdmin,
     MinorTraceChemistryAdmin,
     NotesAdmin,
     ObservationAdmin,
@@ -65,6 +66,7 @@ from db.lexicon import LexiconCategory, LexiconTerm
 from db.location import Location
 from db.nma_legacy import (
     NMA_Chemistry_SampleInfo,
+    NMA_MajorChemistry,
     NMA_MinorTraceChemistry,
     NMA_Radionuclides,
     NMA_HydraulicsData,
@@ -147,6 +149,7 @@ def create_admin(app):
     admin.add_view(HydraulicsDataAdmin(NMA_HydraulicsData))
     admin.add_view(RadionuclidesAdmin(NMA_Radionuclides))
     admin.add_view(MinorTraceChemistryAdmin(NMA_MinorTraceChemistry))
+    admin.add_view(MajorChemistryAdmin(NMA_MajorChemistry))
 
     # Field
     admin.add_view(FieldEventAdmin(FieldEvent))

--- a/admin/views/__init__.py
+++ b/admin/views/__init__.py
@@ -36,6 +36,7 @@ from admin.views.group import GroupAdmin
 from admin.views.hydraulicsdata import HydraulicsDataAdmin
 from admin.views.lexicon import LexiconCategoryAdmin, LexiconTermAdmin
 from admin.views.location import LocationAdmin
+from admin.views.major_chemistry import MajorChemistryAdmin
 from admin.views.minor_trace_chemistry import MinorTraceChemistryAdmin
 from admin.views.notes import NotesAdmin
 from admin.views.observation import ObservationAdmin
@@ -66,6 +67,7 @@ __all__ = [
     "LexiconCategoryAdmin",
     "LexiconTermAdmin",
     "LocationAdmin",
+    "MajorChemistryAdmin",
     "MinorTraceChemistryAdmin",
     "NotesAdmin",
     "ObservationAdmin",

--- a/admin/views/major_chemistry.py
+++ b/admin/views/major_chemistry.py
@@ -1,0 +1,154 @@
+# ===============================================================================
+# Copyright 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""
+MajorChemistryAdmin view for legacy NMA_MajorChemistry.
+"""
+
+import uuid
+
+from starlette.requests import Request
+from starlette_admin.fields import HasOne
+
+from starlette_admin.fields import HasOne
+
+from admin.views.base import OcotilloModelView
+
+
+class MajorChemistryAdmin(OcotilloModelView):
+    """
+    Admin view for NMA_MajorChemistry model.
+    """
+
+    # ========== Basic Configuration ==========
+
+    identity = "n-m-a_-major-chemistry"
+    name = "NMA Major Chemistry"
+    label = "NMA Major Chemistry"
+    icon = "fa fa-flask"
+    pk_attr = "global_id"
+    pk_type = uuid.UUID
+
+    def can_create(self, request: Request) -> bool:
+        return False
+
+    def can_edit(self, request: Request) -> bool:
+        return False
+
+    def can_delete(self, request: Request) -> bool:
+        return False
+
+    # ========== List View ==========
+
+    list_fields = [
+        "global_id",
+        "sample_pt_id",
+        "sample_point_id",
+        HasOne("chemistry_sample_info", identity="n-m-a_-chemistry_-sample-info"),
+        "analyte",
+        "symbol",
+        "sample_value",
+        "units",
+        "uncertainty",
+        "analysis_method",
+        "analysis_date",
+        "notes",
+        "volume",
+        "volume_unit",
+        "object_id",
+        "analyses_agency",
+        "wclab_id",
+    ]
+
+    sortable_fields = [
+        "global_id",
+        "sample_pt_id",
+        "sample_point_id",
+        "analyte",
+        "symbol",
+        "sample_value",
+        "units",
+        "uncertainty",
+        "analysis_method",
+        "analysis_date",
+        "notes",
+        "volume",
+        "volume_unit",
+        "object_id",
+        "analyses_agency",
+        "wclab_id",
+    ]
+
+    fields_default_sort = [("analysis_date", True)]
+
+    searchable_fields = [
+        "global_id",
+        "sample_pt_id",
+        "sample_point_id",
+        "analyte",
+        "symbol",
+        "analysis_method",
+        "notes",
+        "analyses_agency",
+        "wclab_id",
+    ]
+
+    page_size = 50
+    page_size_options = [25, 50, 100, 200]
+
+    # ========== Form View ==========
+
+    fields = [
+        "global_id",
+        "sample_pt_id",
+        "sample_point_id",
+        HasOne("chemistry_sample_info", identity="n-m-a_-chemistry_-sample-info"),
+        "analyte",
+        "symbol",
+        "sample_value",
+        "units",
+        "uncertainty",
+        "analysis_method",
+        "analysis_date",
+        "notes",
+        "volume",
+        "volume_unit",
+        "object_id",
+        "analyses_agency",
+        "wclab_id",
+    ]
+
+    field_labels = {
+        "global_id": "GlobalID",
+        "sample_pt_id": "SamplePtID",
+        "sample_point_id": "SamplePointID",
+        "chemistry_sample_info": "Chemistry Sample Info",
+        "analyte": "Analyte",
+        "symbol": "Symbol",
+        "sample_value": "Sample Value",
+        "units": "Units",
+        "uncertainty": "Uncertainty",
+        "analysis_method": "Analysis Method",
+        "analysis_date": "Analysis Date",
+        "notes": "Notes",
+        "volume": "Volume",
+        "volume_unit": "Volume Unit",
+        "object_id": "OBJECTID",
+        "analyses_agency": "Analyses Agency",
+        "wclab_id": "WCLab_ID",
+    }
+
+
+# ============= EOF =============================================

--- a/admin/views/major_chemistry.py
+++ b/admin/views/major_chemistry.py
@@ -22,8 +22,6 @@ import uuid
 from starlette.requests import Request
 from starlette_admin.fields import HasOne
 
-from starlette_admin.fields import HasOne
-
 from admin.views.base import OcotilloModelView
 
 


### PR DESCRIPTION
<!--
- BDMS-503: Implement read-only admin view for NMAMajorChemistry
-->
### **Why**
_This PR addresses the following problem / context:_
  - Provide a read-only admin view for legacy NMA Major Chemistry records
  - Ensure the admin UI exposes all legacy columns with correct ordering and labels

### **How**
_Implementation summary - the following was changed / added / removed:_
- Added MajorChemistryAdmin view with read-only permissions, list/sort/search config, and labels
  - Included all model columns in list_fields and fields in legacy order, plus the HasOne parent link
  - Registered the new view in admin/views/__init__.py and admin/config.py


### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- None noted
