### PR TITLE
BDMS-502: Implement read-only admin view for NMARadionuclides

### DIFF
--- a/admin/views/radionuclides.py
+++ b/admin/views/radionuclides.py
@@ -16,6 +16,7 @@
 """
 RadionuclidesAdmin view for legacy NMA_Radionuclides.
 """
+from starlette.requests import Request
 
 from admin.views.base import OcotilloModelView
 
@@ -27,13 +28,18 @@ class RadionuclidesAdmin(OcotilloModelView):
 
     # ========== Basic Configuration ==========
 
-    name = "Radionuclides"
-    label = "Radionuclides"
+    name = "NMA Radionuclides"
+    label = "NMA Radionuclides"
     icon = "fa fa-radiation"
 
-    can_create = False
-    can_edit = False
-    can_delete = False
+    def can_create(self, request: Request) -> bool:
+        return False
+
+    def can_edit(self, request: Request) -> bool:
+        return False
+
+    def can_delete(self, request: Request) -> bool:
+        return False
 
     # ========== List View ==========
 
@@ -41,26 +47,38 @@ class RadionuclidesAdmin(OcotilloModelView):
         "global_id",
         "sample_pt_id",
         "sample_point_id",
-        "thing_id",
         "analyte",
+        "symbol",
         "sample_value",
         "units",
+        "uncertainty",
+        "analysis_method",
         "analysis_date",
+        "notes",
+        "volume",
+        "volume_unit",
+        "object_id",
         "analyses_agency",
+        "wclab_id",
     ]
 
     sortable_fields = [
         "global_id",
         "sample_pt_id",
         "sample_point_id",
-        "thing_id",
         "analyte",
+        "symbol",
         "sample_value",
         "units",
+        "uncertainty",
+        "analysis_method",
         "analysis_date",
+        "notes",
+        "volume",
+        "volume_unit",
+        "object_id",
         "analyses_agency",
         "wclab_id",
-        "object_id",
     ]
 
     fields_default_sort = [("analysis_date", True)]
@@ -87,7 +105,6 @@ class RadionuclidesAdmin(OcotilloModelView):
         "global_id",
         "sample_pt_id",
         "sample_point_id",
-        "thing_id",
         "analyte",
         "symbol",
         "sample_value",
@@ -106,20 +123,19 @@ class RadionuclidesAdmin(OcotilloModelView):
     field_labels = {
         "global_id": "GlobalID",
         "sample_pt_id": "SamplePtID",
-        "sample_point_id": "SamplePointID",
-        "thing_id": "Thing ID",
+        "sample_point_id": "Sample PointID",
         "analyte": "Analyte",
         "symbol": "Symbol",
-        "sample_value": "SampleValue",
+        "sample_value": "Sample Value",
         "units": "Units",
         "uncertainty": "Uncertainty",
-        "analysis_method": "AnalysisMethod",
-        "analysis_date": "AnalysisDate",
+        "analysis_method": "Analysis Method",
+        "analysis_date": "Analysis Date",
         "notes": "Notes",
         "volume": "Volume",
-        "volume_unit": "VolumeUnit",
+        "volume_unit": "Volume Unit",
         "object_id": "OBJECTID",
-        "analyses_agency": "AnalysesAgency",
+        "analyses_agency": "Analyses Agency",
         "wclab_id": "WCLab_ID",
     }
 

--- a/admin/views/radionuclides.py
+++ b/admin/views/radionuclides.py
@@ -16,6 +16,7 @@
 """
 RadionuclidesAdmin view for legacy NMA_Radionuclides.
 """
+
 from starlette.requests import Request
 
 from admin.views.base import OcotilloModelView

--- a/db/nma_legacy.py
+++ b/db/nma_legacy.py
@@ -552,9 +552,6 @@ class NMA_Radionuclides(Base):
     global_id: Mapped[uuid.UUID] = mapped_column(
         "GlobalID", UUID(as_uuid=True), primary_key=True
     )
-    thing_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("thing.id", ondelete="CASCADE"), nullable=False
-    )
     sample_pt_id: Mapped[uuid.UUID] = mapped_column(
         "SamplePtID",
         UUID(as_uuid=True),
@@ -584,7 +581,7 @@ class NMA_Radionuclides(Base):
     analyses_agency: Mapped[Optional[str]] = mapped_column("AnalysesAgency", String(50))
     wclab_id: Mapped[Optional[str]] = mapped_column("WCLab_ID", String(25))
 
-    thing: Mapped["Thing"] = relationship("Thing")
+    # Relationships
     chemistry_sample_info: Mapped["NMA_Chemistry_SampleInfo"] = relationship(
         "NMA_Chemistry_SampleInfo", back_populates="radionuclides"
     )


### PR DESCRIPTION
<!--
BDMS-502: Implement read-only admin view for NMARadionuclides
-->
### **Why**
_This PR addresses the following problem / context:_
- Clarify the admin view title and field labels for NMA Radionuclides
- Enforce read-only access using request-aware permissions

### **How**
_Implementation summary - the following was changed / added / removed:_
- Removed redundant foreign key on Radionuclide to Thing.
- Updated admin view name/label to “NMA Radionuclides” in admin/views/radionuclides.py
- Replaced static create/edit/delete flags with request-aware methods returning False
- Adjusted list/sort field order and labels for consistency (e.g., added symbol/uncertainty/volume fields, removed thing_id)

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- None noted
