### PR TITLE
Fix .gitignore formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ transfers/metrics/*
 transfers/logs/*
 run_bdd-local.sh
 .pre-commit-config.local.yaml
+.serena/
 
 # deployment files
-app.yaml.serena/
+app.yaml


### PR DESCRIPTION
## Summary
Fix .gitignore formatting - `.serena/` and `app.yaml` were incorrectly concatenated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)