### PR TITLE
fix(transfers): normalize OwnerKey joins with mapper and collision guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ python -m transfers.transfer
 
 Configure the `.env` file with the appropriate credentials before running transfers.
 
+If contact transfers fail with `OwnerKey normalization collisions`, add or update
+`transfers/data/owners_ownerkey_mapper.json` to map inconsistent `OwnerKey` values
+to a single canonical spelling before re-running the transfer.
+
 To drop the existing schema and rebuild from migrations before transferring data, set:
 
 ```bash

--- a/transfers/contact_transfer.py
+++ b/transfers/contact_transfer.py
@@ -39,6 +39,25 @@ from transfers.util import (
 from transfers.util import read_csv, filter_to_valid_point_ids, replace_nans
 
 
+def _select_ownerkey_col(df: DataFrame, source_name: str) -> str:
+    exact = next((col for col in df.columns if col.lower() == "ownerkey"), None)
+    if exact:
+        return exact
+
+    candidates = [col for col in df.columns if col.lower().endswith("ownerkey")]
+    if not candidates:
+        raise ValueError(
+            f"No owner key column found in {source_name}; expected a column named "
+            "'OwnerKey' (case-insensitive) or ending with 'OwnerKey'."
+        )
+    if len(candidates) > 1:
+        raise ValueError(
+            f"Multiple owner key-like columns found in {source_name}: {candidates}. "
+            "Please disambiguate."
+        )
+    return candidates[0]
+
+
 class ContactTransfer(ThingBasedTransferer):
     source_table = "OwnersData"
 
@@ -85,12 +104,8 @@ class ContactTransfer(ThingBasedTransferer):
         locdf = read_csv("Location")
         ldf = ldf.join(locdf.set_index("LocationId"), on="LocationId")
 
-        owner_key_col = next(
-            col for col in odf.columns if col.lower().endswith("ownerkey")
-        )
-        link_owner_key_col = next(
-            col for col in ldf.columns if col.lower().endswith("ownerkey")
-        )
+        owner_key_col = _select_ownerkey_col(odf, "OwnersData")
+        link_owner_key_col = _select_ownerkey_col(ldf, "OwnerLink")
 
         if self._ownerkey_mapper:
             odf["ownerkey_canonical"] = odf[owner_key_col].map(

--- a/transfers/contact_transfer.py
+++ b/transfers/contact_transfer.py
@@ -62,6 +62,10 @@ class ContactTransfer(ThingBasedTransferer):
             with open(ownerkey_mapper_path, "r") as f:
                 self._ownerkey_mapper = json.load(f)
         except FileNotFoundError:
+            logger.warning(
+                "Owner key mapper file not found at '%s'; proceeding with empty owner key mapping.",
+                ownerkey_mapper_path,
+            )
             self._ownerkey_mapper = {}
 
         self._added = []

--- a/transfers/contact_transfer.py
+++ b/transfers/contact_transfer.py
@@ -57,6 +57,13 @@ class ContactTransfer(ThingBasedTransferer):
         with open(co_to_org_mapper_path, "r") as f:
             self._co_to_org_mapper = json.load(f)
 
+        ownerkey_mapper_path = get_transfers_data_path("owners_ownerkey_mapper.json")
+        try:
+            with open(ownerkey_mapper_path, "r") as f:
+                self._ownerkey_mapper = json.load(f)
+        except FileNotFoundError:
+            self._ownerkey_mapper = {}
+
         self._added = []
 
     def calculate_missing_organizations(self):
@@ -78,7 +85,67 @@ class ContactTransfer(ThingBasedTransferer):
         locdf = read_csv("Location")
         ldf = ldf.join(locdf.set_index("LocationId"), on="LocationId")
 
-        odf = odf.join(ldf.set_index("OwnerKey"), on="OwnerKey")
+        owner_key_col = next(
+            col for col in odf.columns if col.lower().endswith("ownerkey")
+        )
+        link_owner_key_col = next(
+            col for col in ldf.columns if col.lower().endswith("ownerkey")
+        )
+
+        if self._ownerkey_mapper:
+            odf["ownerkey_canonical"] = odf[owner_key_col].map(
+                lambda v: self._ownerkey_mapper.get(v, v)
+            )
+            ldf["ownerkey_canonical"] = ldf[link_owner_key_col].map(
+                lambda v: self._ownerkey_mapper.get(v, v)
+            )
+        else:
+            odf["ownerkey_canonical"] = odf[owner_key_col]
+            ldf["ownerkey_canonical"] = ldf[link_owner_key_col]
+
+        odf["ownerkey_norm"] = (
+            odf["ownerkey_canonical"]
+            .fillna("")
+            .astype(str)
+            .str.strip()
+            .str.casefold()
+            .replace({"": pd.NA})
+        )
+        ldf["ownerkey_norm"] = (
+            ldf["ownerkey_canonical"]
+            .fillna("")
+            .astype(str)
+            .str.strip()
+            .str.casefold()
+            .replace({"": pd.NA})
+        )
+
+        collisions = (
+            ldf.groupby("ownerkey_norm")["ownerkey_canonical"]
+            .nunique(dropna=True)
+            .loc[lambda s: s > 1]
+        )
+        if not collisions.empty:
+            examples = []
+            for key in collisions.index[:10]:
+                variants = (
+                    ldf.loc[ldf["ownerkey_norm"] == key, "ownerkey_canonical"]
+                    .dropna()
+                    .unique()
+                    .tolist()
+                )
+                examples.append(f"{key} -> {sorted(variants)}")
+            logger.critical(
+                "OwnerKey normalization collision(s) detected in OwnerLink. "
+                "Resolve these before proceeding. Examples: %s",
+                "; ".join(examples),
+            )
+            raise ValueError(
+                "OwnerKey normalization collisions detected in OwnerLink. "
+                "Fix source data or update owners_ownerkey_mapper.json."
+            )
+
+        odf = odf.join(ldf.set_index("ownerkey_norm"), on="ownerkey_norm")
 
         odf = replace_nans(odf)
 

--- a/transfers/contact_transfer.py
+++ b/transfers/contact_transfer.py
@@ -145,7 +145,11 @@ class ContactTransfer(ThingBasedTransferer):
                 "Fix source data or update owners_ownerkey_mapper.json."
             )
 
-        odf = odf.join(ldf.set_index("ownerkey_norm"), on="ownerkey_norm")
+        ldf_join = ldf.set_index("ownerkey_norm")
+        overlap_cols = [col for col in ldf_join.columns if col in odf.columns]
+        if overlap_cols:
+            ldf_join = ldf_join.drop(columns=overlap_cols, errors="ignore")
+        odf = odf.join(ldf_join, on="ownerkey_norm")
 
         odf = replace_nans(odf)
 

--- a/transfers/contact_transfer.py
+++ b/transfers/contact_transfer.py
@@ -112,11 +112,11 @@ class ContactTransfer(ThingBasedTransferer):
         link_owner_key_col = _select_ownerkey_col(ldf, "OwnerLink")
 
         if self._ownerkey_mapper:
-            odf["ownerkey_canonical"] = odf[owner_key_col].map(
-                lambda v: self._ownerkey_mapper.get(v, v)
+            odf["ownerkey_canonical"] = odf[owner_key_col].replace(
+                self._ownerkey_mapper
             )
-            ldf["ownerkey_canonical"] = ldf[link_owner_key_col].map(
-                lambda v: self._ownerkey_mapper.get(v, v)
+            ldf["ownerkey_canonical"] = ldf[link_owner_key_col].replace(
+                self._ownerkey_mapper
             )
         else:
             odf["ownerkey_canonical"] = odf[owner_key_col]

--- a/transfers/contact_transfer.py
+++ b/transfers/contact_transfer.py
@@ -40,9 +40,15 @@ from transfers.util import read_csv, filter_to_valid_point_ids, replace_nans
 
 
 def _select_ownerkey_col(df: DataFrame, source_name: str) -> str:
-    exact = next((col for col in df.columns if col.lower() == "ownerkey"), None)
-    if exact:
-        return exact
+    exact_matches = [col for col in df.columns if col.lower() == "ownerkey"]
+    if len(exact_matches) == 1:
+        return exact_matches[0]
+    if len(exact_matches) > 1:
+        raise ValueError(
+            f"Multiple 'OwnerKey' columns found in {source_name}: {exact_matches}. "
+            "Column names differing only by case are ambiguous; please "
+            "disambiguate."
+        )
 
     candidates = [col for col in df.columns if col.lower().endswith("ownerkey")]
     if not candidates:

--- a/transfers/data/owners_ownerkey_mapper.json
+++ b/transfers/data/owners_ownerkey_mapper.json
@@ -1,0 +1,4 @@
+{
+  "Rio en Medio MDWCA": "Rio En Medio MDWCA",
+  "city of Rocks": "City of Rocks"
+}


### PR DESCRIPTION
<!--
- Title the PR with the JIRA project & ticket number and short description (e.g., BDMS-123: Example display bug), or NO TICKET
- Keep sections short and scannable.
-->
### **Why**
_This PR addresses the following problem / context:_
- Contact transfers can silently drop rows when OwnerKey casing differs between OwnersData and OwnerLink
- We need a safe, traceable way to resolve case-only collisions without editing source CSVs


### **How**
_Implementation summary - the following was changed / added / removed:_
1. Added a mapping file to unify/standardize known OwnerKey spelling variants
2. Made the OwnersData ↔ OwnerLink match tolerant to differences in letter casing
3. Added a safety check that stops the transfer and shows examples when matches are ambiguous
4. Documented the mapping file in README.md


### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Update `transfers/data/owners_ownerkey_mapper.json` when new OwnerKey collisions are discovered.
- Collision guard will raise if standardization still leaves ambiguous keys.
- Resolves #479.
- After the next transfer, WL-0359 should be linked to owner "John Kadlecek".