### PR TITLE
BDMS-574: Remove unique contraint on MinorTraceChemistry

### DIFF
--- a/alembic/versions/5336a52336df_drop_minor_trace_chemistry_unique_.py
+++ b/alembic/versions/5336a52336df_drop_minor_trace_chemistry_unique_.py
@@ -10,7 +10,6 @@ from typing import Sequence, Union
 
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision: str = "5336a52336df"
 down_revision: Union[str, Sequence[str], None] = "e71807682f57"

--- a/alembic/versions/5336a52336df_drop_minor_trace_chemistry_unique_.py
+++ b/alembic/versions/5336a52336df_drop_minor_trace_chemistry_unique_.py
@@ -1,0 +1,36 @@
+"""drop minor trace chemistry unique constraint
+
+Revision ID: 5336a52336df
+Revises: e71807682f57
+Create Date: 2026-02-18 14:22:00.874725
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "5336a52336df"
+down_revision: Union[str, Sequence[str], None] = "e71807682f57"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_constraint(
+        "uq_minor_trace_chemistry_sample_analyte",
+        "NMA_MinorTraceChemistry",
+        type_="unique",
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.create_unique_constraint(
+        "uq_minor_trace_chemistry_sample_analyte",
+        "NMA_MinorTraceChemistry",
+        ["chemistry_sample_info_id", "analyte"],
+    )

--- a/db/nma_legacy.py
+++ b/db/nma_legacy.py
@@ -58,7 +58,6 @@ from sqlalchemy import (
     SmallInteger,
     String,
     Text,
-    UniqueConstraint,
     text,
     Identity,
     Index,
@@ -779,13 +778,6 @@ class NMA_MinorTraceChemistry(Base):
     """
 
     __tablename__ = "NMA_MinorTraceChemistry"
-    __table_args__ = (
-        UniqueConstraint(
-            "chemistry_sample_info_id",
-            "analyte",
-            name="uq_minor_trace_chemistry_sample_analyte",
-        ),
-    )
 
     # PK
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)

--- a/transfers/minor_trace_chemistry_transfer.py
+++ b/transfers/minor_trace_chemistry_transfer.py
@@ -114,8 +114,7 @@ class MinorTraceChemistryTransferer(Transferer):
         """
         Override transfer hook to use batch upsert for idempotent transfers.
 
-        Uses ON CONFLICT DO UPDATE on (chemistry_sample_info_id, analyte),
-        matching uq_minor_trace_chemistry_sample_analyte.
+        Uses ON CONFLICT DO UPDATE on nma_GlobalID (legacy UUID PK, now UNIQUE).
         """
         df = self.cleaned_df
 
@@ -130,12 +129,8 @@ class MinorTraceChemistryTransferer(Transferer):
             logger.warning("No valid rows to transfer")
             return
 
-        # Dedupe by the same logical key used by the table unique constraint.
-        rows = self._dedupe_rows(
-            row_dicts,
-            key=["chemistry_sample_info_id", "analyte"],
-            include_missing=True,
-        )
+        # Dedupe by legacy UUID PK (nma_GlobalID) to match upsert conflict key.
+        rows = self._dedupe_rows(row_dicts)
         logger.info(f"Upserting {len(rows)} MinorTraceChemistry records")
 
         insert_stmt = insert(NMA_MinorTraceChemistry)
@@ -144,13 +139,14 @@ class MinorTraceChemistryTransferer(Transferer):
         for i in range(0, len(rows), self.batch_size):
             chunk = rows[i : i + self.batch_size]
             logger.info(f"Upserting batch {i}-{i+len(chunk)-1} ({len(chunk)} rows)")
-            # Upsert on unique logical key (chemistry_sample_info_id, analyte)
+            # Upsert on nma_GlobalID (legacy UUID PK, now UNIQUE)
             stmt = insert_stmt.values(chunk).on_conflict_do_update(
-                index_elements=["chemistry_sample_info_id", "analyte"],
+                index_elements=["nma_GlobalID"],
                 set_={
                     "chemistry_sample_info_id": excluded.chemistry_sample_info_id,
                     "nma_chemistry_sample_info_uuid": excluded.nma_chemistry_sample_info_uuid,
                     "nma_SamplePointID": excluded.nma_SamplePointID,
+                    "analyte": excluded.analyte,
                     "sample_value": excluded.sample_value,
                     "units": excluded.units,
                     "symbol": excluded.symbol,


### PR DESCRIPTION
<!--
BDMS-574: Remove unique constraint on minor/trace chemistry table
-->
### **Why**
_This PR addresses the following problem / context:_
- Legacy data includes multiple MinorTraceChemistry rows per (chemistry_sample_info_id, analyte), so the unique constraint was blocking imports.
- The MinorTraceChemistry transfer needed to align conflict handling with other legacy chemistry tables.

### **How**
_Implementation summary - the following was changed / added / removed:_
- Added a new Alembic migration to drop uq_minor_trace_chemistry_sample_analyte on NMA_MinorTraceChemistry (with downgrade to restore it).
- Updated the MinorTraceChemistry transfer to upsert on nma_GlobalID (matching MajorChemistry, Radionuclides, and FieldParameters).
- Kept the migration head aligned with e71807682f57.


### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Migration applied locally; if not already applied elsewhere, run alembic upgrade head.
- Integration tests were run successfully.
- Did not run a test transfer to confirm successful migration of records
- Resolves #502
