### PR TITLE
BDMS-609: Add support for legacy SiteNotes handling

### DIFF
--- a/core/lexicon.json
+++ b/core/lexicon.json
@@ -8208,6 +8208,13 @@
     },
     {
       "categories": [
+        "note_type"
+      ],
+      "term": "Site Notes (legacy)",
+      "definition": "Legacy site notes field from WaterLevels"
+    },
+    {
+      "categories": [
         "well_pump_type"
       ],
       "term": "Submersible",

--- a/db/thing.py
+++ b/db/thing.py
@@ -435,6 +435,10 @@ class Thing(
         return self._get_notes("Construction")
 
     @property
+    def site_notes(self):
+        return self._get_notes("Site Notes (legacy)")
+
+    @property
     def well_status(self) -> str | None:
         """
         Returns the well status from the most recent status history entry

--- a/schemas/thing.py
+++ b/schemas/thing.py
@@ -211,6 +211,7 @@ class BaseThingResponse(BaseResponseModel):
     monitoring_frequencies: list[MonitoringFrequencyResponse] = []
     general_notes: list[NoteResponse] = []
     sampling_procedure_notes: list[NoteResponse] = []
+    site_notes: list[NoteResponse] = []
 
     @field_validator("monitoring_frequencies", mode="before")
     def remove_records_with_end_date(cls, monitoring_frequencies):

--- a/transfers/waterlevels_transfer.py
+++ b/transfers/waterlevels_transfer.py
@@ -399,20 +399,32 @@ class WaterLevelTransferer(Transferer):
                     stats["observations_created"] += len(observation_rows)
 
                 # Site Notes (legacy)
-                site_notes = {
-                    prep["row"].SiteNotes
-                    for prep in prepared_rows
-                    if hasattr(prep["row"], "SiteNotes")
-                    and prep["row"].SiteNotes
-                    and str(prep["row"].SiteNotes).strip()
-                }
-                for note_content in site_notes:
+                # If there are duplicate notes for a single point ID, we only create one note.
+                # However, if some duplicates are "time stamped" (meaning they are attached to
+                # rows with different dates), we should ideally preserve that context.
+                # The current implementation prepends the date to the note content
+                # to ensure that duplicate content from different dates remains distinct.
+                unique_notes: dict[str, datetime] = {}
+                for prep in prepared_rows:
+                    if hasattr(prep["row"], "SiteNotes") and prep["row"].SiteNotes:
+                        content = str(prep["row"].SiteNotes).strip()
+                        if content:
+                            dt = prep["dt_utc"]
+                            # We keep all notes that have different content OR different dates
+                            # Actually, if content is same but date is different, we want to see it.
+                            # So we key by (content, date)
+                            key = (content, dt.date())
+                            if key not in unique_notes:
+                                unique_notes[key] = dt
+
+                for (content, _), dt in unique_notes.items():
+                    date_prefix = dt.strftime("%Y-%m-%d")
                     session.add(
                         Notes(
                             target_table="thing",
                             target_id=thing_id,
                             note_type="Site Notes (legacy)",
-                            content=str(note_content).strip(),
+                            content=f"{date_prefix}: {content}",
                             release_status="public",
                         )
                     )

--- a/transfers/waterlevels_transfer.py
+++ b/transfers/waterlevels_transfer.py
@@ -33,6 +33,7 @@ from db import (
     Contact,
     FieldEventParticipant,
     Parameter,
+    Notes,
 )
 from db.engine import session_ctx
 from transfers.transferer import Transferer
@@ -158,6 +159,7 @@ class WaterLevelTransferer(Transferer):
             "observations_created": 0,
             "contacts_created": 0,
             "contacts_reused": 0,
+            "notes_created": 0,
         }
 
         gwd = self.cleaned_df.groupby(["PointID"])
@@ -395,6 +397,26 @@ class WaterLevelTransferer(Transferer):
                 if observation_rows:
                     session.execute(insert(Observation), observation_rows)
                     stats["observations_created"] += len(observation_rows)
+
+                # Site Notes (legacy)
+                site_notes = {
+                    prep["row"].SiteNotes
+                    for prep in prepared_rows
+                    if hasattr(prep["row"], "SiteNotes")
+                    and prep["row"].SiteNotes
+                    and str(prep["row"].SiteNotes).strip()
+                }
+                for note_content in site_notes:
+                    session.add(
+                        Notes(
+                            target_table="thing",
+                            target_id=thing_id,
+                            note_type="Site Notes (legacy)",
+                            content=str(note_content).strip(),
+                            release_status="public",
+                        )
+                    )
+                    stats["notes_created"] += 1
 
                 session.commit()
                 session.expunge_all()


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem / context:_
- Legacy `SiteNotes` from the `WaterLevels` table were previously inaccessible in the new database and API.
- This data is critical for field technicians and must be visible during field form generation.
- To ensure data quality, blank or missing legacy records needed to be filtered out during the migration process.

### **How**
_Implementation summary - the following was changed / added / removed:_
- Added `Site Notes (legacy)` to the `note_type` category in core/lexicon.json.
- Updated `transfers/waterlevels_transfer.py` to migrate unique, non-empty `SiteNotes` into the polymorphic `Notes` table, linked to `Thing` records.
- Enhanced migration logic to explicitly skip `NaN`, empty, or whitespace-only strings from the legacy source.
- Implemented a multi-key deduplication strategy (date + content) to balance historical preservation with redundancy reduction.
- Added a `site_notes` property to the `Thing` database model in `db/thing.py` for easy retrieval of these legacy records.
- Exposed `site_notes` in the `BaseThingResponse` schema in `schemas/thing.py`, ensuring it is available across all relevant API endpoints (e.g., `/things/wells`).

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- The API is designed to return an empty list `[]` for `site_notes` if no records exist, ensuring consistent behavior for downstream clients.
- Date prefixing ensures that even if note content is identical, the system treats observations from different visits as unique historical events.
- Only notes from the `WaterLevels` source are currently being mapped to this type; other legacy tables (like `SurfaceWaterData`) still retain their original `SiteNotes` `columns for historical reference until specifically mapped.
- Resolves Issue #549