### PR TITLE
BDMS-610: Add `Windmill` to lexicon `well_pump_type` category

### DIFF
--- a/core/lexicon.json
+++ b/core/lexicon.json
@@ -8243,6 +8243,13 @@
     },
     {
       "categories": [
+        "well_pump_type"
+      ],
+      "term": "Windmill",
+      "definition": "Windmill"
+    },
+    {
+      "categories": [
         "permission_type"
       ],
       "term": "Water Level Sample",


### PR DESCRIPTION
<!--
BDMS-610: Add `Windmill` to lexicon `well_pump_type` category
-->
### **Why**
_This PR addresses the following problem / context:_
- Windmill is a common pump type in NM and should be part of the `well_pump_type` lexicon.

### **How**
_Implementation summary - the following was changed / added / removed:_
- Added `Windmill` as a `well_pump_type` in the lexicon.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- None
