### PR TITLE
Backfill orchestrator should log outcomes and preserve tracebacks

### DIFF
--- a/transfers/backfill/backfill.py
+++ b/transfers/backfill/backfill.py
@@ -49,8 +49,15 @@ def run(batch_size: int = 1000) -> None:
             logger.info(f"Skipping backfill: {name} ({flag}=false)")
             continue
         logger.info(f"Starting backfill: {name}")
-        fn(batch_size)
-        logger.info(f"Completed backfill: {name}")
+        result = fn(batch_size)
+        logger.info(
+            f"Completed backfill: {name} — "
+            f"inserted={result.inserted} updated={result.updated} "
+            f"skipped_orphans={result.skipped_orphans} errors={len(result.errors)}"
+        )
+        if result.errors:
+            for err in result.errors:
+                logger.warning(f"  {name}: {err}")
 
 
 def _parse_args() -> argparse.Namespace:
@@ -69,7 +76,7 @@ if __name__ == "__main__":
     try:
         run(batch_size=args.batch_size)
     except Exception as exc:
-        logger.critical(f"Backfill orchestration failed: {exc}")
+        logger.critical("Backfill orchestration failed", exc_info=True)
         sys.exit(1)
 
 # ============= EOF =============================================

--- a/transfers/backfill/backfill.py
+++ b/transfers/backfill/backfill.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     args = _parse_args()
     try:
         run(batch_size=args.batch_size)
-    except Exception as exc:
+    except Exception:
         logger.critical("Backfill orchestration failed", exc_info=True)
         sys.exit(1)
 


### PR DESCRIPTION
## Summary
- Capture and log `BackfillResult` summary (inserted/updated/skipped_orphans/errors) instead of discarding the return value
- Log individual errors at WARNING level for operator visibility
- Preserve full traceback on critical failure via `exc_info=True` instead of f-string

## Refs
Closes #563, closes #564
Part of #558

## Blocks
- #565 — chemistry backfill note-creation lookup hardening
- #566 — chemistry backfill test cleanup error handling
- #567 — scoped AnalysisMethod test cleanup
- #568 — unused parameter_ids tracker cleanup

These issues depend on code introduced by #558 and will be addressed on that feature branch.

## Test plan
- [ ] No functional behavior change — `steps` tuple is currently empty on staging
- [ ] Verify logging output when backfill steps are wired up in #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)