### PR TITLE
feat: update test configuration to use specific PostGIS version and improve database readiness checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,14 +31,25 @@ jobs:
       SESSION_SECRET_KEY: supersecretkeyforunittests
       AUTHENTIK_DISABLE_AUTHENTICATION: 1
 
+    services:
+      postgis:
+        image: postgis/postgis:17-3.5
+        # don't test against latest. be explicit in version being tested to avoid breaking changes
+        # image: postgis/postgis:latest
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_PORT: 5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
       - name: Check out source repository
         uses: actions/checkout@v6.0.2
-
-      - name: Start database (PostGIS)
-        run: |
-          docker compose build db
-          docker compose up -d db
 
       - name: Wait for database readiness
         run: |
@@ -91,10 +102,6 @@ jobs:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Stop database
-        if: always()
-        run: docker compose down -v
-
   bdd-tests:
     runs-on: ubuntu-latest
 
@@ -116,14 +123,25 @@ jobs:
       AUTHENTIK_DISABLE_AUTHENTICATION: 1
       DROP_AND_REBUILD_DB: 1
 
+    services:
+      postgis:
+        image: postgis/postgis:17-3.5
+        # don't test against latest. be explicit in version being tested to avoid breaking changes
+        # image: postgis/postgis:latest
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_PORT: 5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
       - name: Check out source repository
         uses: actions/checkout@v6.0.2
-
-      - name: Start database (PostGIS)
-        run: |
-          docker compose build db
-          docker compose up -d db
 
       - name: Wait for database readiness
         run: |
@@ -169,7 +187,3 @@ jobs:
 
       - name: Run BDD tests
         run: uv run behave tests/features --tags="@backend and @production and not @skip" --no-capture
-
-      - name: Stop database
-        if: always()
-        run: docker compose down -v


### PR DESCRIPTION
## Summary
Revert `.github/workflows/tests.yml` from `docker compose`-managed DB startup back to native GitHub Actions `services.postgis`.

## Why
`docker compose` was introduced when CI needed `pg_cron` support via a custom DB image build.  
`pg_cron` has since been removed from test setup and is no longer a dependency, so the compose-based path is unnecessary overhead.

## Changes
1. Added `services.postgis` to both `unit-tests` and `bdd-tests` jobs using `postgis/postgis:17-3.5`.
2. Removed `Start database (PostGIS)` steps that ran:
   - `docker compose build db`
   - `docker compose up -d db`
3. Removed `Stop database` steps that ran:
   - `docker compose down -v`
4. Kept existing DB readiness checks and DB/bootstrap SQL unchanged (`CREATE DATABASE`, `CREATE EXTENSION IF NOT EXISTS postgis`).

## Impact
- Simplifies CI workflow.
- Avoids image build time in test jobs.
- Aligns DB setup with current dependency set (PostGIS only).

## Validation
- Workflow file updated for both test jobs.
- No application/runtime code changes.