### PR TITLE
feat: add water elevation materialized view and update configuration

### DIFF
--- a/alembic/versions/m6f7a8b9c0d1_add_water_elevation_materialized_view.py
+++ b/alembic/versions/m6f7a8b9c0d1_add_water_elevation_materialized_view.py
@@ -1,0 +1,116 @@
+"""add water elevation materialized view
+
+Revision ID: m6f7a8b9c0d1
+Revises: c7f8a9b0d1e2
+Create Date: 2026-03-09 10:45:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import inspect, text
+
+# revision identifiers, used by Alembic.
+revision: str = "m6f7a8b9c0d1"
+down_revision: Union[str, Sequence[str], None] = "c7f8a9b0d1e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+LATEST_LOCATION_CTE = """
+SELECT DISTINCT ON (lta.thing_id)
+    lta.thing_id,
+    lta.location_id,
+    lta.effective_start
+FROM location_thing_association AS lta
+WHERE lta.effective_end IS NULL
+ORDER BY lta.thing_id, lta.effective_start DESC
+""".strip()
+
+
+def _create_water_elevation_view() -> str:
+    return f"""
+        CREATE MATERIALIZED VIEW ogc_water_elevation_wells AS
+        WITH latest_location AS (
+{LATEST_LOCATION_CTE}
+        ),
+        ranked_obs AS (
+            SELECT
+                fe.thing_id,
+                o.id AS observation_id,
+                o.observation_datetime,
+                (o.value - COALESCE(o.measuring_point_height, 0))
+                    AS depth_to_water_below_ground_surface,
+                ROW_NUMBER() OVER (
+                    PARTITION BY fe.thing_id
+                    ORDER BY o.observation_datetime DESC, o.id DESC
+                ) AS rn
+            FROM observation AS o
+            JOIN sample AS s ON s.id = o.sample_id
+            JOIN field_activity AS fa ON fa.id = s.field_activity_id
+            JOIN field_event AS fe ON fe.id = fa.field_event_id
+            JOIN thing AS t ON t.id = fe.thing_id
+            WHERE
+                t.thing_type = 'water well'
+                AND fa.activity_type = 'groundwater level'
+                AND o.value IS NOT NULL
+                AND o.observation_datetime IS NOT NULL
+        )
+        SELECT
+            t.id AS id,
+            t.name,
+            t.thing_type,
+            ro.observation_id,
+            ro.observation_datetime,
+            l.elevation,
+            ro.depth_to_water_below_ground_surface,
+            (
+                l.elevation - ro.depth_to_water_below_ground_surface
+            ) AS water_elevation,
+            l.point
+        FROM ranked_obs AS ro
+        JOIN thing AS t ON t.id = ro.thing_id
+        JOIN latest_location AS ll ON ll.thing_id = t.id
+        JOIN location AS l ON l.id = ll.location_id
+        WHERE ro.rn = 1
+    """
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing_tables = set(inspector.get_table_names(schema="public"))
+    required_tables = {
+        "thing",
+        "location",
+        "location_thing_association",
+        "observation",
+        "sample",
+        "field_activity",
+        "field_event",
+    }
+
+    if not required_tables.issubset(existing_tables):
+        missing = sorted(t for t in required_tables if t not in existing_tables)
+        raise RuntimeError(
+            "Cannot create ogc_water_elevation_wells. Missing required tables: "
+            + ", ".join(missing)
+        )
+
+    op.execute(text("DROP MATERIALIZED VIEW IF EXISTS ogc_water_elevation_wells"))
+    op.execute(text(_create_water_elevation_view()))
+    op.execute(
+        text(
+            "COMMENT ON MATERIALIZED VIEW ogc_water_elevation_wells IS "
+            "'Latest water elevation per well (elevation minus depth to water below ground surface).'"
+        )
+    )
+    op.execute(
+        text(
+            "CREATE UNIQUE INDEX ux_ogc_water_elevation_wells_id "
+            "ON ogc_water_elevation_wells (id)"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(text("DROP MATERIALIZED VIEW IF EXISTS ogc_water_elevation_wells"))

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -52,6 +52,7 @@ class SmokePopulation(str, Enum):
 
 PYGEOAPI_MATERIALIZED_VIEWS = (
     "ogc_latest_depth_to_water_wells",
+    "ogc_water_elevation_wells",
     "ogc_avg_tds_wells",
     "ogc_depth_to_water_trend_wells",
     "ogc_water_well_summary",

--- a/core/pygeoapi-config.yml
+++ b/core/pygeoapi-config.yml
@@ -149,6 +149,29 @@ resources:
         table: ogc_depth_to_water_trend_wells
         geom_field: point
 
+  water_elevation_wells:
+    type: collection
+    title: Water Elevation (Water Wells)
+    description: Most recent water elevation per well calculated as elevation minus depth to water below ground surface.
+    keywords: [water-wells, groundwater-level, water-elevation, depth-to-water]
+    extents:
+      spatial:
+        bbox: [-109.05, 31.33, -103.00, 37.00]
+        crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+    providers:
+      - type: feature
+        name: PostgreSQL
+        data:
+          host: {postgres_host}
+          port: {postgres_port}
+          dbname: {postgres_db}
+          user: {postgres_user}
+          password: {postgres_password_env}
+          search_path: [public]
+        id_field: id
+        table: ogc_water_elevation_wells
+        geom_field: point
+
   water_well_summary:
     type: collection
     title: Water Well Summary

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -338,12 +338,10 @@ def test_water_levels_cli_persists_observations(tmp_path, water_well_thing):
     """
 
     def _write_csv(path: Path, *, well_name: str, notes: str):
-        csv_text = textwrap.dedent(
-            f"""\
+        csv_text = textwrap.dedent(f"""\
             field_staff,well_name_point_id,field_event_date_time,measurement_date_time,sampler,sample_method,mp_height,level_status,depth_to_water_ft,data_quality,water_level_notes
             CLI Tester,{well_name},2025-02-15T08:00:00-07:00,2025-02-15T10:30:00-07:00,Groundwater Team,electric tape,1.5,stable,42.5,approved,{notes}
-            """
-        )
+            """)
         path.write_text(csv_text)
 
     unique_notes = f"pytest-{uuid.uuid4()}"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -55,6 +55,7 @@ def test_refresh_pygeoapi_materialized_views_defaults(monkeypatch):
     assert result.exit_code == 0, result.output
     assert executed_sql == [
         "REFRESH MATERIALIZED VIEW ogc_latest_depth_to_water_wells",
+        "REFRESH MATERIALIZED VIEW ogc_water_elevation_wells",
         "REFRESH MATERIALIZED VIEW ogc_avg_tds_wells",
         "REFRESH MATERIALIZED VIEW ogc_depth_to_water_trend_wells",
         "REFRESH MATERIALIZED VIEW ogc_water_well_summary",
@@ -62,7 +63,7 @@ def test_refresh_pygeoapi_materialized_views_defaults(monkeypatch):
         "REFRESH MATERIALIZED VIEW ogc_minor_chemistry_wells",
     ]
     assert commit_called["value"] is True
-    assert "Refreshed 6 materialized view(s)." in result.output
+    assert "Refreshed 7 materialized view(s)." in result.output
 
 
 def test_refresh_pygeoapi_materialized_views_custom_and_concurrently(monkeypatch):
@@ -337,10 +338,12 @@ def test_water_levels_cli_persists_observations(tmp_path, water_well_thing):
     """
 
     def _write_csv(path: Path, *, well_name: str, notes: str):
-        csv_text = textwrap.dedent(f"""\
+        csv_text = textwrap.dedent(
+            f"""\
             field_staff,well_name_point_id,field_event_date_time,measurement_date_time,sampler,sample_method,mp_height,level_status,depth_to_water_ft,data_quality,water_level_notes
             CLI Tester,{well_name},2025-02-15T08:00:00-07:00,2025-02-15T10:30:00-07:00,Groundwater Team,electric tape,1.5,stable,42.5,approved,{notes}
-            """)
+            """
+        )
         path.write_text(csv_text)
 
     unique_notes = f"pytest-{uuid.uuid4()}"

--- a/tests/test_ogc.py
+++ b/tests/test_ogc.py
@@ -327,6 +327,26 @@ def test_ogc_minor_chemistry_wells_uses_latest_per_analyte(water_well_thing):
         session.commit()
 
 
+def test_ogc_water_elevation_wells_computes_elevation_minus_depth_to_water(
+    water_well_thing, groundwater_level_observation
+):
+    with session_ctx() as session:
+        session.execute(text("REFRESH MATERIALIZED VIEW ogc_water_elevation_wells"))
+        session.commit()
+
+        row = session.execute(
+            text(
+                "SELECT elevation, depth_to_water_below_ground_surface, water_elevation "
+                "FROM ogc_water_elevation_wells WHERE id = :thing_id"
+            ),
+            {"thing_id": water_well_thing.id},
+        ).one()
+
+        assert float(row.depth_to_water_below_ground_surface) == 5.0
+        assert float(row.elevation) == 2464.9
+        assert abs(float(row.water_elevation) - 2459.9) < 1e-9
+
+
 def test_ogc_collections():
     response = client.get("/ogcapi/collections")
     assert response.status_code == 200
@@ -338,6 +358,7 @@ def test_ogc_collections():
         "springs",
         "latest_tds_wells",
         "depth_to_water_trend_wells",
+        "water_elevation_wells",
         "water_well_summary",
         "major_chemistry_results",
         "minor_chemistry_wells",
@@ -348,6 +369,7 @@ def test_ogc_new_collection_items_endpoints():
     for collection_id in (
         "latest_tds_wells",
         "depth_to_water_trend_wells",
+        "water_elevation_wells",
         "water_well_summary",
         "major_chemistry_results",
         "minor_chemistry_wells",


### PR DESCRIPTION
## Summary
This PR adds a new OGC materialized view for **water elevation** and linearizes the Alembic migration history to a single head.

`water_elevation` is computed as:

`elevation - depth_to_water_below_ground_surface`

## What Changed
- Added migration to create `ogc_water_elevation_wells`:
    - [m6f7a8b9c0d1_add_water_elevation_materialized_view.py](/Users/jakeross/_Programming/_DIG/NMSampleLocations/alembic/versions/m6f7a8b9c0d1_add_water_elevation_materialized_view.py)
- Added OGC collection config:
    - [pygeoapi-config.yml](/Users/jakeross/_Programming/_DIG/NMSampleLocations/core/pygeoapi-config.yml)
    - New collection id: `water_elevation_wells`
- Included new materialized view in CLI refresh defaults:
    - [cli.py](/Users/jakeross/_Programming/_DIG/NMSampleLocations/cli/cli.py)
- Updated tests:
    - [test_ogc.py](/Users/jakeross/_Programming/_DIG/NMSampleLocations/tests/test_ogc.py)
        - Added direct assertion for water elevation computation.
        - Added collection presence and items endpoint coverage.
    - [test_cli_commands.py](/Users/jakeross/_Programming/_DIG/NMSampleLocations/tests/test_cli_commands.py)
        - Updated expected refreshed view list/count.
- Linearized Alembic history:
    - Updated `m6f7a8b9c0d1` to revise `c7f8a9b0d1e2` (instead of `l5e6f7a8b9c0`), leaving a single migration head.

## Why
- Exposes water elevation as a first-class OGC dataset for map/feature clients.
- Keeps Alembic migration graph healthy (single head), avoiding merge-migration churn and CI failures.

## Validation
- `python -m py_compile` passes for changed Python files.
- `alembic heads` now returns one head: `m6f7a8b9c0d1`.