### PR TITLE
Make GCS optional for transfer elevation cache and cleanup

### DIFF
--- a/transfers/well_transfer_util.py
+++ b/transfers/well_transfer_util.py
@@ -20,7 +20,7 @@ from pandas import isna
 from sqlalchemy.orm import Session
 
 from db import GeologicFormation, Location
-from services.gcs_helper import get_storage_bucket
+from services.gcs_helper import GCS_BUCKET_NAME, get_storage_bucket
 from services.util import (
     get_state_from_point,
     get_county_from_point,
@@ -156,6 +156,8 @@ def get_or_create_geologic_formation(
 
 
 def get_cached_elevations() -> dict:
+    if not GCS_BUCKET_NAME:
+        return {}
     bucket = get_storage_bucket()
     log_filename = "transfer_data/cached_elevations.json"
     blob = bucket.blob(log_filename)
@@ -163,6 +165,8 @@ def get_cached_elevations() -> dict:
 
 
 def dump_cached_elevations(lut: dict):
+    if not GCS_BUCKET_NAME:
+        return
     bucket = get_storage_bucket()
     log_filename = "transfer_data/cached_elevations.json"
     blob = bucket.blob(log_filename)
@@ -174,17 +178,19 @@ def cleanup_locations(session):
     n = len(locations)
     lut = {}
 
-    bucket = get_storage_bucket()
-    log_filename = "transfer_data/location_cleanup.json"
-    blob = bucket.blob(log_filename)
-    if blob.exists():
-        lut = download_blob_json(blob, default={})
+    if GCS_BUCKET_NAME:
+        bucket = get_storage_bucket()
+        log_filename = "transfer_data/location_cleanup.json"
+        blob = bucket.blob(log_filename)
+        if blob.exists():
+            lut = download_blob_json(blob, default={})
 
     updates = []
     for i, location in enumerate(locations):
         if i and not i % 100:
-            logger.info(f"Processing row {i} of {n}. dumping lut to {log_filename}")
-            upload_blob_json(blob, lut)
+            logger.info(f"Processing row {i} of {n}")
+            if GCS_BUCKET_NAME:
+                upload_blob_json(blob, lut)
             session.bulk_update_mappings(Location, updates)
             session.commit()
             updates = []
@@ -222,7 +228,8 @@ def cleanup_locations(session):
             f"={quad_name}"
         )
 
-    upload_blob_json(blob, lut)
+    if GCS_BUCKET_NAME:
+        upload_blob_json(blob, lut)
     if updates:
         session.bulk_update_mappings(Location, updates)
         session.commit()


### PR DESCRIPTION
## Summary

Makes Google Cloud Storage (GCS) optional for the data transfer pipeline. When `GCS_BUCKET_NAME` is not set, the transfer runs without GCS instead of failing with `ValueError: Cannot determine path without bucket name.`

## Problem

Running `python -m transfers.transfer` locally (without GCS credentials) failed during well transfer initialization. `WellTransferer` calls `get_cached_elevations()` to load a precomputed elevation cache from GCS. If `GCS_BUCKET_NAME` is empty or unset, the GCS client creates a bucket object with no name, and `blob.exists()` raises:

```
ValueError: Cannot determine path without bucket name.
```


This blocked local development and testing of the transfer without GCS.

## Solution

Guard all GCS usage in `well_transfer_util.py` with a check for `GCS_BUCKET_NAME`:

- **`get_cached_elevations()`** – Returns an empty dict when GCS is not configured. The transfer proceeds without a cache; elevation lookups may be slower or use defaults.
- **`dump_cached_elevations()`** – No-op when GCS is not configured. The in-memory cache is not persisted.
- **`cleanup_locations()`** – Skips GCS read/write when GCS is not configured. Location updates (state, county, quad_name) still run using in-memory lookups; only the GCS-backed cache is skipped.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `GCS_BUCKET_NAME` set | Uses GCS for elevation cache and location cleanup cache | Same behavior |
| `GCS_BUCKET_NAME` unset or empty | Transfer crashes on well transfer init | Transfer runs; GCS operations are skipped |

## Testing

- Run `python -m transfers.transfer` with `GCS_BUCKET_NAME` unset in `.env`; the transfer should complete successfully.
- With `GCS_BUCKET_NAME` set and valid credentials, the transfer should still use GCS for elevation and location cleanup caches.