### PR TITLE
Handle pg_dump restrict commands in local restore

### DIFF
--- a/cli/db_restore.py
+++ b/cli/db_restore.py
@@ -21,6 +21,12 @@ ROLE_DEPENDENT_SQL_PATTERNS = (
     re.compile(r"^\s*REVOKE\b", re.IGNORECASE),
     re.compile(r"^\s*ALTER\s+DEFAULT\s+PRIVILEGES\b", re.IGNORECASE),
 )
+PSQL_META_COMMAND_PATTERNS = (
+    # Newer pg_dump versions emit these psql-only commands for safer restores.
+    # Older local psql clients reject them, so drop them from staged restores.
+    re.compile(r"^\s*\\restrict\b", re.IGNORECASE),
+    re.compile(r"^\s*\\unrestrict\b", re.IGNORECASE),
+)
 
 
 class LocalDbRestoreError(RuntimeError):
@@ -81,9 +87,13 @@ def _sanitize_sql_dump(source_path: Path, target_path: Path) -> None:
         with open(source_path, "r", encoding="utf-8") as infile:
             with open(target_path, "w", encoding="utf-8") as outfile:
                 for line in infile:
-                    if any(
+                    matches_role_sql = any(
                         pattern.search(line) for pattern in ROLE_DEPENDENT_SQL_PATTERNS
-                    ):
+                    )
+                    matches_psql_meta = any(
+                        pattern.search(line) for pattern in PSQL_META_COMMAND_PATTERNS
+                    )
+                    if matches_role_sql or matches_psql_meta:
                         continue
                     outfile.write(line)
     except UnicodeError as exc:
@@ -235,6 +245,7 @@ def restore_local_db_from_sql(
             ) from exc
 
         return LocalDbRestoreResult(
+            sql_file=staged_sql_file,
             source=source_description,
             host=host,
             port=port,

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -164,10 +164,12 @@ def test_associate_assets_command_calls_service(monkeypatch):
 def test_restore_local_db_invokes_psql(monkeypatch, tmp_path):
     sql_file = tmp_path / "restore.sql"
     sql_file.write_text(
+        "\\restrict abc123\n"
         "SET ROLE ocotillo;\n"
         "ALTER TABLE public.sample OWNER TO ocotillo;\n"
         "GRANT ALL ON TABLE public.sample TO ocotillo;\n"
         "select 1;\n"
+        "\\unrestrict abc123\n"
     )
     captured: dict[str, object] = {}
     call_order: list[str] = []
@@ -532,10 +534,12 @@ def test_water_levels_cli_persists_observations(tmp_path, water_well_thing):
     """
 
     def _write_csv(path: Path, *, well_name: str, notes: str):
-        csv_text = textwrap.dedent(f"""\
+        csv_text = textwrap.dedent(
+            f"""\
             field_staff,well_name_point_id,field_event_date_time,measurement_date_time,sampler,sample_method,mp_height,level_status,depth_to_water_ft,data_quality,water_level_notes
             CLI Tester,{well_name},2025-02-15T08:00:00-07:00,2025-02-15T10:30:00-07:00,Groundwater Team,electric tape,1.5,stable,42.5,approved,{notes}
-            """)
+            """
+        )
         path.write_text(csv_text)
 
     unique_notes = f"pytest-{uuid.uuid4()}"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -534,12 +534,10 @@ def test_water_levels_cli_persists_observations(tmp_path, water_well_thing):
     """
 
     def _write_csv(path: Path, *, well_name: str, notes: str):
-        csv_text = textwrap.dedent(
-            f"""\
+        csv_text = textwrap.dedent(f"""\
             field_staff,well_name_point_id,field_event_date_time,measurement_date_time,sampler,sample_method,mp_height,level_status,depth_to_water_ft,data_quality,water_level_notes
             CLI Tester,{well_name},2025-02-15T08:00:00-07:00,2025-02-15T10:30:00-07:00,Groundwater Team,electric tape,1.5,stable,42.5,approved,{notes}
-            """
-        )
+            """)
         path.write_text(csv_text)
 
     unique_notes = f"pytest-{uuid.uuid4()}"


### PR DESCRIPTION
## Summary
- strip pg_dump `\restrict` and `\unrestrict` meta-commands from staged restore SQL before invoking local psql
- keep returning the staged SQL path in the restore result so successful restores do not fail constructing the result object
- add CLI test coverage for restores from dumps that include the new pg_dump meta-commands

## Testing
- source .venv/bin/activate && pytest tests/test_cli_commands.py -k restore_local_db