### PR TITLE
BDMS-658: add location properties and contact summaries to well responses

### DIFF
--- a/schemas/location.py
+++ b/schemas/location.py
@@ -101,6 +101,9 @@ class GeoJSONProperties(BaseModel):
     elevation_unit: str = "ft"
     vertical_datum: str = "NAVD88"
     elevation_method: ElevationMethod | None
+    county: str | None = None
+    state: str | None = None
+    quad_name: str | None = None
     utm_coordinates: GeoJSONUTMCoordinates = Field(
         default_factory=GeoJSONUTMCoordinates
     )
@@ -154,6 +157,9 @@ class LocationGeoJSONResponse(BaseModel):
         data_dict["properties"]["notes"] = data_dict.get("notes")
         data_dict["properties"]["elevation"] = convert_m_to_ft(elevation_m)
         data_dict["properties"]["elevation_method"] = data_dict.get("elevation_method")
+        data_dict["properties"]["county"] = data_dict.get("county")
+        data_dict["properties"]["state"] = data_dict.get("state")
+        data_dict["properties"]["quad_name"] = data_dict.get("quad_name")
         data_dict["properties"]["nma_location_notes"] = data_dict.get(
             "nma_location_notes"
         )

--- a/schemas/thing.py
+++ b/schemas/thing.py
@@ -229,6 +229,13 @@ class BaseThingResponse(BaseResponseModel):
         return active_frequencies
 
 
+class WellContactSummaryResponse(BaseResponseModel):
+    name: str | None = None
+    organization: str | None = None
+    role: str
+    contact_type: str
+
+
 class WellResponse(BaseThingResponse):
     """
     Response schema for well details.
@@ -262,6 +269,7 @@ class WellResponse(BaseThingResponse):
     aquifers: list[dict] = []
     water_notes: list[NoteResponse] = []
     construction_notes: list[NoteResponse] = []
+    contacts: list[WellContactSummaryResponse] = []
     permissions: list[PermissionHistoryResponse]
     formation_completion_code: FormationCode | None
     nma_formation_zone: str | None

--- a/schemas/thing.py
+++ b/schemas/thing.py
@@ -28,6 +28,8 @@ from core.enums import (
     WellPumpType,
     FormationCode,
     OriginType,
+    Role,
+    ContactType,
 )
 from schemas import BaseCreateModel, BaseUpdateModel, BaseResponseModel, PastOrTodayDate
 from schemas.group import GroupResponse
@@ -232,8 +234,8 @@ class BaseThingResponse(BaseResponseModel):
 class WellContactSummaryResponse(BaseResponseModel):
     name: str | None = None
     organization: str | None = None
-    role: str
-    contact_type: str
+    role: Role
+    contact_type: ContactType
 
 
 class WellResponse(BaseThingResponse):

--- a/services/thing_helper.py
+++ b/services/thing_helper.py
@@ -28,6 +28,7 @@ from starlette.status import HTTP_404_NOT_FOUND, HTTP_409_CONFLICT
 from db import (
     LocationThingAssociation,
     Thing,
+    ThingContactAssociation,
     Location,
     WellScreen,
     WellPurpose,
@@ -54,6 +55,9 @@ WELL_DESCRIPTOR_MODEL_MAP = {
 WATER_WELL_LOADER_OPTIONS = [
     selectinload(Thing.location_associations).selectinload(
         LocationThingAssociation.location
+    ),
+    selectinload(Thing.contact_associations).selectinload(
+        ThingContactAssociation.contact
     ),
     selectinload(Thing.well_purposes),
     selectinload(Thing.well_casing_materials),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,10 @@ def location():
         loc = Location(
             point="POINT(-107.949533 33.809665)",
             elevation=2464.9,
+            county="Sierra",
             release_status="draft",
+            state="NM",
+            quad_name="Hillsboro Peak",
         )
 
         session.add(loc)

--- a/tests/test_thing.py
+++ b/tests/test_thing.py
@@ -690,7 +690,10 @@ def test_get_water_wells_includes_contact_summary(
     assert response.status_code == 200
     data = response.json()
 
-    well = next(item for item in data["items"] if item["id"] == water_well_thing.id)
+    well = next(
+        (item for item in data["items"] if item["id"] == water_well_thing.id), None
+    )
+    assert well is not None, f"Well {water_well_thing.id} not found in response"
     assert well["contacts"] == [
         {
             "id": contact.id,

--- a/tests/test_thing.py
+++ b/tests/test_thing.py
@@ -668,6 +668,42 @@ def test_get_water_well_details_payload_404_not_found():
     assert response.json()["detail"] == "Thing with ID 999999 not found."
 
 
+def test_get_water_well_by_id_includes_location_properties(
+    water_well_thing,
+):
+    response = client.get(f"/thing/water-well/{water_well_thing.id}")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["current_location"]["properties"]["county"] == "Sierra"
+    assert data["current_location"]["properties"]["state"] == "NM"
+    assert data["current_location"]["properties"]["quad_name"] == "Hillsboro Peak"
+
+
+def test_get_water_wells_includes_contact_summary(
+    water_well_thing,
+    contact,
+):
+    response = client.get("/thing/water-well")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    well = next(item for item in data["items"] if item["id"] == water_well_thing.id)
+    assert well["contacts"] == [
+        {
+            "id": contact.id,
+            "created_at": contact.created_at.astimezone(timezone.utc).strftime(DT_FMT),
+            "release_status": contact.release_status,
+            "name": contact.name,
+            "organization": contact.organization,
+            "contact_type": contact.contact_type,
+            "role": contact.role,
+        }
+    ]
+
+
 def test_get_water_well_by_id_404_not_found(water_well_thing):
     bad_id = 99999
     response = client.get(f"/thing/water-well/{bad_id}")


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem / context:_
- The wells list and related thing responses exposed coordinates from the current location, but not the location metadata already stored on `Location`.
- The wells list also omitted associated contact summaries needed by the UI.
- The list response needed to include contact data without introducing N+1 queries.

### **How**
_Implementation summary - the following was changed / added / removed:_
- Added `county`, `state`, and `quad_name` to `GeoJSONProperties` and populated them in `LocationGeoJSONResponse.populate_fields`.
- Added a compact `contacts` summary field to `WellResponse` with `id`, `name`, `organization`, `contact_type`, and `role`.
- Extended the existing well loader options to eagerly load `contact_associations -> contact` so the well list response can include contacts efficiently.
- Updated shared test fixtures and added focused response tests for the new location metadata and well-list contact summary.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Validation run: `pytest tests/test_thing.py -k "includes_location_properties or includes_contact_summary or details_payload or get_water_well_by_id_404_not_found or get_water_well_by_id_404_wrong_type or get_spring_by_id_404_not_found or get_spring_by_id_404_wrong_type"`
- `black` passed on the touched files.
- `flake8` on the touched files has an existing baseline of `E501` and `F403/F405`; after removing the one new actionable warning from this change, targeted lint with those baseline rules ignored passed.