### PR TITLE
Add first_field_event to well details response

### DIFF
--- a/schemas/well_details.py
+++ b/schemas/well_details.py
@@ -51,3 +51,4 @@ class WellDetailsResponse(BaseModel):
     deployments: list[DeploymentResponse] = Field(default_factory=list)
     well_screens: list[WellScreenBaseResponse] = Field(default_factory=list)
     field_events: list[WellDetailsFieldEventResponse] = Field(default_factory=list)
+    first_field_event: WellDetailsFieldEventResponse | None = None

--- a/services/well_details_helper.py
+++ b/services/well_details_helper.py
@@ -111,11 +111,9 @@ def get_well_details_payload(
                 .order_by(WellScreen.screen_depth_top.asc(), WellScreen.id.asc())
             ).all()
 
-        _participant_options = (
-            selectinload(FieldEvent.field_event_participants).selectinload(
-                FieldEventParticipant.participant
-            )
-        )
+        _participant_options = selectinload(
+            FieldEvent.field_event_participants
+        ).selectinload(FieldEventParticipant.participant)
         _activity_options = [
             selectinload(FieldEvent.field_activities)
             .selectinload(FieldActivity.samples)

--- a/services/well_details_helper.py
+++ b/services/well_details_helper.py
@@ -111,26 +111,39 @@ def get_well_details_payload(
                 .order_by(WellScreen.screen_depth_top.asc(), WellScreen.id.asc())
             ).all()
 
+        _participant_options = (
+            selectinload(FieldEvent.field_event_participants).selectinload(
+                FieldEventParticipant.participant
+            )
+        )
+        _activity_options = [
+            selectinload(FieldEvent.field_activities)
+            .selectinload(FieldActivity.samples)
+            .selectinload(Sample.field_event_participant)
+            .selectinload(FieldEventParticipant.participant),
+            selectinload(FieldEvent.field_activities)
+            .selectinload(FieldActivity.samples)
+            .selectinload(Sample.observations)
+            .selectinload(Observation.parameter),
+        ]
+
         with _payload_stage_timer("well_details", "load_field_events", thing_id):
             field_events = session.scalars(
                 select(FieldEvent)
                 .where(FieldEvent.thing_id == well.id)
-                .options(
-                    selectinload(FieldEvent.field_event_participants).selectinload(
-                        FieldEventParticipant.participant
-                    ),
-                    selectinload(FieldEvent.field_activities)
-                    .selectinload(FieldActivity.samples)
-                    .selectinload(Sample.field_event_participant)
-                    .selectinload(FieldEventParticipant.participant),
-                    selectinload(FieldEvent.field_activities)
-                    .selectinload(FieldActivity.samples)
-                    .selectinload(Sample.observations)
-                    .selectinload(Observation.parameter),
-                )
+                .options(_participant_options, *_activity_options)
                 .order_by(FieldEvent.event_date.desc(), FieldEvent.id.desc())
                 .limit(field_event_limit)
             ).all()
+
+        with _payload_stage_timer("well_details", "load_first_field_event", thing_id):
+            first_field_event = session.scalars(
+                select(FieldEvent)
+                .where(FieldEvent.thing_id == well.id)
+                .options(_participant_options)
+                .order_by(FieldEvent.event_date.asc(), FieldEvent.id.asc())
+                .limit(1)
+            ).first()
 
         return {
             "well": well,
@@ -139,6 +152,7 @@ def get_well_details_payload(
             "deployments": deployments,
             "well_screens": well_screens,
             "field_events": field_events,
+            "first_field_event": first_field_event,
         }
 
 


### PR DESCRIPTION
The field_events query returns the 25 most recent events sorted newest-first. For wells with many visits the oldest event falls outside that window, making it impossible to retrieve first-visit participants from the paged list.

This adds a separate targeted query that always fetches the single oldest field event (_with participants_) and returns it as `first_field_event` alongside the existing paged `field_events` list.