### PR TITLE
Fall back to organization name for org-only contacts in search

### DIFF
--- a/api/search.py
+++ b/api/search.py
@@ -67,7 +67,7 @@ def _get_contact_results(session: Session, q: str, limit: int) -> list[dict]:
     contacts = session.scalars(query).all()
     results = [
         {
-            "label": c.name,
+            "label": c.name or c.organization,
             "group": "Contacts",
             "properties": {
                 "email": [e.email for e in c.emails],


### PR DESCRIPTION
## Summary

- Org-only contacts (those with `organization` set but no `name`) were returning a `null` label in search results, causing them to appear with a blank title in the search modal.
- `_get_contact_results` in `api/search.py` now uses `c.name or c.organization` so org-only contacts surface with their organization name.

## Part of

This is the API half of a two-repo fix for empty contact display names. The UI half (OcotilloUI) adds a `getContactDisplayName` utility function and applies it to the wells list, well detail Contacts card, contacts list page, and contact show page.

See also: https://github.com/DataIntegrationGroup/OcotilloUI/pull/275

## Test plan

- [ ] Search for a contact that has only an organization name (no personal name) and confirm it appears with the org name as the result title
- [ ] Confirm contacts with a personal name still show the personal name as the result title
- [ ] Confirm contacts with both name and organization show the personal name