### PR TITLE
Add new organization terms for well inventory ingestion

### DIFF
--- a/core/lexicon.json
+++ b/core/lexicon.json
@@ -2706,6 +2706,13 @@
       "categories": [
         "organization"
       ],
+      "term": "Cerro MDWCA",
+      "definition": "Cerro MDWCA"
+    },
+    {
+      "categories": [
+        "organization"
+      ],
       "term": "Farr Cattle Company",
       "definition": "Farr Cattle Company (Farr Ranch)"
     },
@@ -2715,6 +2722,13 @@
       ],
       "term": "Carrizozo Orchard",
       "definition": "Carrizozo Orchard"
+    },
+    {
+      "categories": [
+        "organization"
+      ],
+      "term": "White Oaks Pottery",
+      "definition": "White Oaks Pottery"
     },
     {
       "categories": [
@@ -2743,6 +2757,13 @@
       ],
       "term": "El Rito Regional Water and Waste Water Association",
       "definition": "El Rito Regional Water + Waste Water Association"
+    },
+    {
+      "categories": [
+        "organization"
+      ],
+      "term": "El Rito MDWCA",
+      "definition": "El Rito MDWCA"
     },
     {
       "categories": [


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem / context:_
- Introduces new organization terms to support well inventory ingestion. Well inventory records with organizations missing from the lexicon fail ingestion.

### **How**
_Implementation summary - the following was changed / added / removed:_
- Added Cerro MDWCA, White Oaks Pottery, and El Rito MDWCA organizations to the lexicon.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- None at this time.