### PR TITLE
feat(lexicon): add new organization terms in support of the 2026-05-26 well inventory ingestion

### DIFF
--- a/core/lexicon.json
+++ b/core/lexicon.json
@@ -4568,6 +4568,27 @@
       "categories": [
         "organization"
       ],
+      "term": "Santa Ana Pueblo Department of Natural Resources",
+      "definition": "Santa Ana Pueblo Department of Natural Resources"
+    },
+    {
+      "categories": [
+        "organization"
+      ],
+      "term": "Village of Hope",
+      "definition": "Village of Hope"
+    },
+    {
+      "categories": [
+        "organization"
+      ],
+      "term": "WSP",
+      "definition": "WSP"
+    },
+    {
+      "categories": [
+        "organization"
+      ],
       "term": "Zia Pueblo",
       "definition": "Zia Pueblo"
     },


### PR DESCRIPTION
<!--
NO TICKET: add new organization terms in support of well inventory ingestion
-->
### **Why**
_This PR addresses the following problem / context:_
- The May 26, 2026 ingestion requires these organizations to exist in the lexicon so incoming records can map cleanly without introducing invalid organization values.

### **How**
_Implementation summary - the following was changed / added / removed:_
Adds three organization terms to core/lexicon.json in support of the May 26, 2026 data ingestion:

  - Santa Ana Pueblo Department of Natural Resources
  - WSP
  - Village of Hope

  These entries did not already exist in the lexicon, so they were added as new organization terms.


### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- None
