### PR TITLE
fix: validate thing_id before GCS upload to prevent orphaned blobs

### DIFF
--- a/api/asset.py
+++ b/api/asset.py
@@ -239,15 +239,7 @@ async def upload_and_record_asset(
             ],
         )
 
-    # ── 3. Upload file to GCS (blocking I/O — run in thread pool) ────────────
-    uri, blob_name = await run_in_threadpool(gcs_upload, file, bucket)
-
-    # ── 4. Return existing record for duplicate file + thing combinations ─────
-    existing = check_asset_exists(session, blob_name, thing_id=thing_id)
-    if existing:
-        return existing
-
-    # ── 5. Validate the Thing exists ─────────────────────────────────────────
+    # ── 3. Validate the Thing exists (before upload to avoid orphaned blobs) ─
     thing = session.get(Thing, thing_id)
     if thing is None:
         raise PydanticStyleException(
@@ -261,6 +253,14 @@ async def upload_and_record_asset(
                 }
             ],
         )
+
+    # ── 4. Upload file to GCS (blocking I/O — run in thread pool) ────────────
+    uri, blob_name = await run_in_threadpool(gcs_upload, file, bucket)
+
+    # ── 5. Return existing record for duplicate file + thing combinations ─────
+    existing = check_asset_exists(session, blob_name, thing_id=thing_id)
+    if existing:
+        return existing
 
     # ── 6. Persist the Asset record ───────────────────────────────────────────
     asset = Asset(


### PR DESCRIPTION
### Why
- `POST /asset/upload-and-record` uploaded the file to GCS *before* calling `session.get(Thing, thing_id)`. When `thing_id` was invalid, the endpoint then raised 409 and returned — leaving an orphaned object in GCS with no `Asset` row pointing at it.
- Affects otherwise valid multipart uploads that reference a nonexistent `thing_id`.

### How
- Moved the `Thing` lookup ahead of `gcs_upload` in [api/asset.py:242](api/asset.py:242).
- Numbered comment-section ordering updated accordingly.

### Notes
- Existing test `test_upload_and_record_asset_bad_thing_id` ([tests/test_asset.py:452](tests/test_asset.py:452)) still asserts the same 409 contract.
- No GCS-orphan assertion added — would require mocking `gcs_upload` to confirm it isn't called; current test suite doesn't reach actual GCS in CI.