### PR TITLE
test: replace removed CliRunner.isolated_filesystem with tmp_path

### DIFF
--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -701,12 +701,10 @@ def test_water_levels_cli_persists_observations(tmp_path, water_well_thing):
             "Water level accurate to within two hundreths of a foot,"
             f"{notes}"
         )
-        csv_text = textwrap.dedent(
-            f"""\
+        csv_text = textwrap.dedent(f"""\
             {header}
             {row}
-            """
-        )
+            """)
         path.write_text(csv_text)
 
     unique_notes = f"pytest-{uuid.uuid4()}"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -254,7 +254,7 @@ def test_initialize_lexicon_invokes_initializer(monkeypatch):
     assert called["count"] == 1
 
 
-def test_associate_assets_command_calls_service(monkeypatch):
+def test_associate_assets_command_calls_service(monkeypatch, tmp_path):
     captured = {}
 
     def fake_associate(source_directory):
@@ -263,13 +263,11 @@ def test_associate_assets_command_calls_service(monkeypatch):
 
     monkeypatch.setattr("cli.service_adapter.associate_assets", fake_associate)
 
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        workdir = Path.cwd()
-        asset_dir = workdir / "asset_import_batch"
-        asset_dir.mkdir()
+    asset_dir = tmp_path / "asset_import_batch"
+    asset_dir.mkdir()
 
-        result = runner.invoke(cli, ["associate-assets", str(asset_dir)])
+    runner = CliRunner()
+    result = runner.invoke(cli, ["associate-assets", str(asset_dir)])
 
     assert result.exit_code == 0, result.output
     assert captured["path"] == asset_dir
@@ -703,10 +701,12 @@ def test_water_levels_cli_persists_observations(tmp_path, water_well_thing):
             "Water level accurate to within two hundreths of a foot,"
             f"{notes}"
         )
-        csv_text = textwrap.dedent(f"""\
+        csv_text = textwrap.dedent(
+            f"""\
             {header}
             {row}
-            """)
+            """
+        )
         path.write_text(csv_text)
 
     unique_notes = f"pytest-{uuid.uuid4()}"


### PR DESCRIPTION
### Why
- `test_associate_assets_command_calls_service` fails:
  `AttributeError: 'CliRunner' object has no attribute 'isolated_filesystem'`
- Click's `CliRunner` dropped the `isolated_filesystem()` context manager in the version now resolved.

### How
- Use the pytest `tmp_path` fixture to create the `asset_import_batch` dir, matching the pattern other tests in this file already use ([tests/test_cli_commands.py:257](tests/test_cli_commands.py:257)).
- Black additionally normalized one unrelated `textwrap.dedent` block in `test_water_levels_cli_persists_observations` (pre-existing format drift the pre-commit hook fixed).

### Notes
- Local run still blocked by Postgres auth in dev `.env`; CI exercises it.