### PR TITLE
fix: pin joserfc in requirements.txt to unblock deploy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1035,6 +1035,10 @@ jinja2==3.1.6 \
     #   ocotilloapi
     #   pygeoapi
     #   starlette-admin
+joserfc==1.7.1 \
+    --hash=sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81 \
+    --hash=sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164
+    # via authlib
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce


### PR DESCRIPTION
### Why
- Deploy buildpack fails:
  ```
  ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
  joserfc>=1.6.0 ... (from authlib==1.7.2->-r requirements.txt (line 225))
  ```
- authlib `1.6.x → 1.7.2` added **joserfc** as a new runtime dependency. The lockfile bump updated `uv.lock` / `pyproject.toml` but `requirements.txt` was not regenerated, so joserfc was missing. pip then resolved it transitively as the unpinned `joserfc>=1.6.0`, which `--require-hashes` rejects.

### How
- Add `joserfc==1.7.1` with its sdist + `py3-none-any` wheel hashes copied from `uv.lock`. Pure-python wheel → platform-independent, so both hashes are complete.
- Verified joserfc is the **only** non-dev dependency present in `uv.lock` but missing from `requirements.txt` (all other gaps are dev-group deps excluded by `--no-dev`).

### Notes
- Surgical one-package insert rather than a full `uv export` regen (local uv 0.9.7 emits a different per-platform hash set than CI, which would churn ~1000 lines).
- **Production is currently broken by this** — staging→production release will carry the fix; if production needs it sooner, cherry-pick to a `hotfix/v*` branch.