### PR TITLE
ci: deploy production inline from release-please (fix missing release tag trigger)

### DIFF
--- a/.github/workflows/CD_production.yml
+++ b/.github/workflows/CD_production.yml
@@ -26,13 +26,13 @@ jobs:
     # (v*.*.*, v*.*.*-*, v*.*.*[a-z]*). startsWith() is a cheap pre-filter;
     # the "Validate release tag" step enforces the strict regex. The tag comes
     # from the workflow_call input or, for the release event, the payload.
-    if: ${{ startsWith(inputs.tag_name || github.event.release.tag_name, 'v') }}
+    if: ${{ startsWith((github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name, 'v') }}
 
     runs-on: ubuntu-latest
     environment: production
 
     env:
-      DEPLOY_TAG: ${{ inputs.tag_name || github.event.release.tag_name }}
+      DEPLOY_TAG: ${{ (github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name }}
 
     steps:
       - name: Validate release tag matches version pattern

--- a/.github/workflows/CD_production.yml
+++ b/.github/workflows/CD_production.yml
@@ -1,6 +1,19 @@
 name: CD (Production)
 
 on:
+  # Reusable entry point: release-please calls this inline after it creates a
+  # release. Releases that release-please makes with the default GITHUB_TOKEN do
+  # NOT emit a `release: published` event that triggers other workflows
+  # (GitHub's recursive-trigger block), so the release-please workflow invokes
+  # this one directly via workflow_call.
+  workflow_call:
+    inputs:
+      tag_name:
+        description: Release tag to deploy (e.g. v1.1.0)
+        required: true
+        type: string
+  # Fallback for releases published manually (UI) or via a PAT, which DO emit a
+  # release event.
   release:
     types: [published]
 
@@ -11,19 +24,21 @@ jobs:
   production-deploy:
     # Safety rail: only deploy when the release tag is version-shaped
     # (v*.*.*, v*.*.*-*, v*.*.*[a-z]*). startsWith() is a cheap pre-filter;
-    # the "Validate release tag" step enforces the strict regex.
-    if: startsWith(github.event.release.tag_name, 'v')
+    # the "Validate release tag" step enforces the strict regex. The tag comes
+    # from the workflow_call input or, for the release event, the payload.
+    if: ${{ startsWith(inputs.tag_name || github.event.release.tag_name, 'v') }}
 
     runs-on: ubuntu-latest
     environment: production
 
+    env:
+      DEPLOY_TAG: ${{ inputs.tag_name || github.event.release.tag_name }}
+
     steps:
       - name: Validate release tag matches version pattern
-        env:
-          TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+|[a-z].*)?$ ]]; then
-            echo "Release tag '$TAG' does not match the v*.*.* pattern. Refusing to deploy."
+          if [[ ! "$DEPLOY_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+|[a-z].*)?$ ]]; then
+            echo "Release tag '$DEPLOY_TAG' does not match the v*.*.* pattern. Refusing to deploy."
             exit 1
           fi
 
@@ -33,7 +48,7 @@ jobs:
           fetch-depth: 0
           # Fully-qualified tag ref avoids ambiguity if a branch is ever
           # created with the same name as the release tag.
-          ref: refs/tags/${{ github.event.release.tag_name }}
+          ref: refs/tags/${{ env.DEPLOY_TAG }}
 
       - name: Install uv in container
         uses: astral-sh/setup-uv@v8.2.0
@@ -82,7 +97,7 @@ jobs:
 
       - name: Render App Engine configs
         env:
-          APP_VERSION: ${{ github.event.release.tag_name }}
+          APP_VERSION: ${{ env.DEPLOY_TAG }}
           ENVIRONMENT: "production"
           CLOUD_SQL_INSTANCE_NAME: "${{ secrets.CLOUD_SQL_INSTANCE_NAME }}"
           CLOUD_SQL_DATABASE: "${{ vars.CLOUD_SQL_DATABASE }}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,6 +31,8 @@ jobs:
   deploy-production:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/CD_production.yml
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,25 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - id: release
+        uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: ${{ github.ref_name }}
+
+  # When release-please actually cuts a release, deploy it. The release is
+  # created with GITHUB_TOKEN, whose events don't trigger other workflows, so we
+  # invoke the production deploy inline (same run) instead of relying on the
+  # `release: published` event reaching CD_production.
+  deploy-production:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/CD_production.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
### Why
After merging staging → production, release-please opens its release PR and (on merge) creates the GitHub release + tag — but **CD (Production) never runs**.

Root cause: release-please creates the release/tag with the default `GITHUB_TOKEN`. GitHub deliberately does **not** emit workflow-triggering events for actions taken with `GITHUB_TOKEN` (recursive-trigger protection). So the `release: published` event never reaches CD (Production), and nothing deploys.

### How
Run the deploy as a job in the **same** workflow run as release-please, which sidesteps the cascade restriction — no PAT needed.

- **CD_production.yml**: now a reusable workflow.
  - Add `workflow_call` trigger with a `tag_name` input.
  - Resolve the deploy tag via a job-level `DEPLOY_TAG = inputs.tag_name || github.event.release.tag_name`, used by the validate step, the `refs/tags/…` checkout, and `APP_VERSION`.
  - Keep the version-shape guard (`if:` + regex step).
  - Retain `release: published` as a fallback for releases published via the UI or a PAT.
- **release-please.yml**: expose `release_created` / `tag_name` outputs and add a `deploy-production` job that `uses: ./.github/workflows/CD_production.yml` with `secrets: inherit`, gated on `release_created == 'true'`.

### Flow after this
1. Merge staging → production → release-please opens release PR.
2. Merge release PR → push to production → release-please creates release+tag **and** the `deploy-production` job deploys it in the same run.

### Notes
- No double-deploy: when release-please makes the release (GITHUB_TOKEN), `release: published` does not fire; only the inline call deploys. A manual UI/PAT release fires the fallback path instead.
- `production` environment protection rules still apply to the called job.
- YAML validated locally.