### PR TITLE
ci: fix production deploy skipping when invoked via workflow_call

### DIFF
--- a/.github/workflows/CD_production.yml
+++ b/.github/workflows/CD_production.yml
@@ -26,13 +26,16 @@ jobs:
     # (v*.*.*, v*.*.*-*, v*.*.*[a-z]*). startsWith() is a cheap pre-filter;
     # the "Validate release tag" step enforces the strict regex. The tag comes
     # from the workflow_call input or, for the release event, the payload.
-    if: ${{ startsWith((github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name, 'v') }}
+    # NOTE: a called workflow inherits the CALLER's event context, so
+    # github.event_name is never 'workflow_call' here — inputs.tag_name is
+    # simply empty when triggered by a release event, so `||` falls through.
+    if: ${{ startsWith(inputs.tag_name || github.event.release.tag_name, 'v') }}
 
     runs-on: ubuntu-latest
     environment: production
 
     env:
-      DEPLOY_TAG: ${{ (github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name }}
+      DEPLOY_TAG: ${{ inputs.tag_name || github.event.release.tag_name }}
 
     steps:
       - name: Validate release tag matches version pattern


### PR DESCRIPTION
## Problem

Merging [#711](https://github.com/DataIntegrationGroup/OcotilloAPI/pull/711) created release v1.1.0 but never deployed it. In [run 27302759728](https://github.com/DataIntegrationGroup/OcotilloAPI/actions/runs/27302759728) the `deploy-production / production-deploy` job was **skipped**.

## Cause

A reusable workflow inherits the **caller's** event context — `github.event_name` is never `workflow_call`. So in `CD_production.yml`:

```yaml
if: ${{ startsWith((github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name, 'v') }}
```

`github.event_name` was `push`, the left side evaluated false, `github.event.release.tag_name` is empty on a push event, and `startsWith('', 'v')` → job skipped.

## Fix

Drop the event-name check. `inputs.tag_name` is simply empty when the workflow is triggered by a `release` event, so `||` fallback behavior is preserved:

```yaml
if: ${{ startsWith(inputs.tag_name || github.event.release.tag_name, 'v') }}
```

Same fix applied to the `DEPLOY_TAG` env expression.

## Notes

- Must reach the `production` branch before the next release-please run picks it up (workflow_call resolves the called workflow at the pushed SHA).
- The `release: published` fallback path was never affected — re-publishing v1.1.0 from the UI will deploy it with the current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)