### PR TITLE
ci: sync uv.lock in forward-merge PRs after release version bump

### DIFF
--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -151,9 +151,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
         with:
+          fetch-depth: 0
           ref: ${{ inputs.source_branch }}
           token: ${{ secrets.FORWARD_MERGE_TOKEN || github.token }}
-
       - name: Set up git user
         run: |
           git config user.name  "github-actions[bot]"

--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -97,6 +97,25 @@ jobs:
             git commit -m "chore: sync staging release-please manifest to ${TAG}"
           fi
 
+      # release-please bumps the project version in pyproject.toml but never
+      # touches uv.lock, which records the editable ocotilloapi version.
+      # tests.yml runs `uv sync --locked`, so the back-merge PR fails CI until
+      # the lockfile is re-locked (see commit 27751110). Idempotent: no
+      # lockfile change -> no commit.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Sync uv.lock to released version
+        run: |
+          uv lock
+          if ! git diff --quiet -- uv.lock; then
+            git add uv.lock
+            git commit -m "chore: sync uv.lock to released version ${TAG#v}"
+          fi
+
       # Retry-safe: skip if a PR is already open for this merge; force-with-lease
       # handles a branch left behind by a previous partial run.
       - name: Push branch and open PR
@@ -131,6 +150,35 @@ jobs:
       SOURCE: ${{ inputs.source_branch }}
     steps:
       - uses: actions/checkout@v6.0.3
+        with:
+          ref: ${{ inputs.source_branch }}
+          token: ${{ secrets.FORWARD_MERGE_TOKEN || github.token }}
+
+      - name: Set up git user
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # The PR head is the hotfix branch itself, so the lockfile sync commit
+      # (release-please bumped pyproject.toml but not uv.lock; tests run
+      # `uv sync --locked`) is pushed directly to the hotfix branch before the
+      # PR is opened. Idempotent: lockfile already in sync -> no commit, no
+      # push. Plain push (not force) so an out-of-date checkout fails loudly
+      # instead of clobbering newer hotfix commits.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Sync uv.lock to released version
+        run: |
+          uv lock
+          if ! git diff --quiet -- uv.lock; then
+            git add uv.lock
+            git commit -m "chore: sync uv.lock to released version ${TAG#v}"
+            git push origin "HEAD:${SOURCE}"
+          fi
 
       # Retry-safe: skip if a PR is already open from this hotfix branch.
       - name: Open PR hotfix -> production


### PR DESCRIPTION
## What

Adds a `uv.lock` re-lock step to both jobs in `.github/workflows/forward-merge.yml`:

- **back-merge-to-staging**: after the release-please manifest sync, install uv (`astral-sh/setup-uv@v8.2.0`, same pin as tests.yml/CD workflows), run `uv lock`, and commit the lockfile to the merge branch if it changed — before the existing push/PR step.
- **forward-merge-to-production**: the PR head is the hotfix branch itself, so the checkout now pins `ref: inputs.source_branch` (with `FORWARD_MERGE_TOKEN`), runs `uv lock`, and pushes a sync commit directly to the hotfix branch before opening the PR.

## Why

release-please bumps the project version in `pyproject.toml` when cutting releases on `production` and `hotfix/v*`, but never updates `uv.lock`, which records the editable ocotilloapi package version. `tests.yml` runs `uv sync --locked`, which asserts the lockfile is unchanged — so every back-merge and hotfix forward-merge PR failed CI until someone manually ran `uv lock` and committed. This was done by hand for #714 (27751110); this PR automates it.

## Reviewer notes

- Both sync steps are idempotent: lockfile already in sync → no commit, no push. Safe on retry.
- Existing retry-safety untouched: existing-PR checks and `--force-with-lease` on the merge branch behave as before.
- Hotfix path uses a **plain push** (not force) to the hotfix branch on purpose — an out-of-date checkout fails loudly instead of clobbering newer hotfix commits.
- The release tag stays on the original release commit; the lockfile sync commit rides on top and is included in the PR. No new release is triggered.
- `uv lock` in CI needs network access for resolution — standard on these runners.
- Not exercised live yet; first real validation is the back-merge PR after the next production release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)