### PR TITLE
fix(openapi): resolve schema generation failures

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -128,7 +128,8 @@ def create_base_app() -> FastAPI:
                     (
                         r
                         for r in app.routes
-                        if r.path == path and method.upper() in r.methods
+                        if getattr(r, "path", None) == path
+                        and method.upper() in getattr(r, "methods", set())
                     ),
                     None,
                 )

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 from fastapi import Depends
 from sqlalchemy.orm import Session
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Session
 from core.permissions import authenticated
 from db.engine import get_db_session
 
-session_dependency: type[Session] = Annotated[Session, Depends(get_db_session)]
+session_dependency: TypeAlias = Annotated[Session, Depends(get_db_session)]
 
 """
 Developer Notes
@@ -61,18 +61,18 @@ no_permission_function = authenticated(permissions=["NoPermission"])
 
 
 # Permissions Dependencies -----------------------------------------------------
-admin_dependency: type[dict] = Annotated[dict, Depends(admin_function)]
-editor_dependency: type[dict] = Annotated[dict, Depends(editor_function)]
-viewer_dependency: type[dict] = Annotated[dict, Depends(viewer_function)]
+admin_dependency: TypeAlias = Annotated[dict, Depends(admin_function)]
+editor_dependency: TypeAlias = Annotated[dict, Depends(editor_function)]
+viewer_dependency: TypeAlias = Annotated[dict, Depends(viewer_function)]
 
-lexicon_admin_dependency: type[dict] = Annotated[dict, Depends(lexicon_admin_function)]
-lexicon_editor_dependency: type[dict] = Annotated[
+lexicon_admin_dependency: TypeAlias = Annotated[dict, Depends(lexicon_admin_function)]
+lexicon_editor_dependency: TypeAlias = Annotated[
     dict, Depends(lexicon_editor_function)
 ]
 
-amp_admin_dependency: type[dict] = Annotated[dict, Depends(amp_admin_function)]
-amp_editor_dependency: type[dict] = Annotated[dict, Depends(amp_editor_function)]
-amp_viewer_dependency: type[dict] = Annotated[dict, Depends(amp_viewer_function)]
+amp_admin_dependency: TypeAlias = Annotated[dict, Depends(amp_admin_function)]
+amp_editor_dependency: TypeAlias = Annotated[dict, Depends(amp_editor_function)]
+amp_viewer_dependency: TypeAlias = Annotated[dict, Depends(amp_viewer_function)]
 
-no_permission_dependency: type[dict] = Annotated[dict, Depends(no_permission_function)]
+no_permission_dependency: TypeAlias = Annotated[dict, Depends(no_permission_function)]
 # ============= EOF =============================================

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -66,9 +66,7 @@ editor_dependency: TypeAlias = Annotated[dict, Depends(editor_function)]
 viewer_dependency: TypeAlias = Annotated[dict, Depends(viewer_function)]
 
 lexicon_admin_dependency: TypeAlias = Annotated[dict, Depends(lexicon_admin_function)]
-lexicon_editor_dependency: TypeAlias = Annotated[
-    dict, Depends(lexicon_editor_function)
-]
+lexicon_editor_dependency: TypeAlias = Annotated[dict, Depends(lexicon_editor_function)]
 
 amp_admin_dependency: TypeAlias = Annotated[dict, Depends(amp_admin_function)]
 amp_editor_dependency: TypeAlias = Annotated[dict, Depends(amp_editor_function)]


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem/context:_
- Fixes OpenAPI generation failures caused by dependency aliases being typed incorrectly.
- Prevents OpenAPI customization logic from crashing when `app.routes` contains non-route router objects.

### **How**
_Implementation summary - the following was changed/added/removed:_
- Updated shared dependency aliases in `core/dependencies.py` to use `TypeAlias` instead of `type[...]`.
- Updated the OpenAPI route lookup in `core/app.py` to safely access path and methods using `getattr()`.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- This should resolve the `_IncludedRouter` attribute error during `/openapi.json` generation.
- Verify by running the app locally and confirming `/docs` and `/openapi.json` both load successfully.