### PR TITLE
fix(deploy): prevent App Engine request starvation under burst load

### DIFF
--- a/.github/app.template.yaml
+++ b/.github/app.template.yaml
@@ -8,6 +8,7 @@ inbound_services:
 automatic_scaling:
   min_instances: ${MIN_INSTANCES}
   max_instances: ${MAX_INSTANCES}
+  max_concurrent_requests: 6
 handlers:
   - url: /.*
     secure: always

--- a/.github/workflows/CD_production.yml
+++ b/.github/workflows/CD_production.yml
@@ -120,8 +120,8 @@ jobs:
         run: |
           export MAX_INSTANCES="10"
           export SERVICE_NAME="ocotillo-api"
-          export ENTRYPOINT="gunicorn -w 4 -k uvicorn.workers.UvicornWorker main:app"
-          export MIN_INSTANCES="0"
+          export ENTRYPOINT="gunicorn -w 8 -k uvicorn.workers.UvicornWorker main:app"
+          export MIN_INSTANCES="1"
           envsubst < .github/app.template.yaml > app.yaml
 
       - name: Deploy to Google Cloud


### PR DESCRIPTION
## Hotfix for production (v1.1.1)

Targets **hotfix/v1.1.1** (branched off tag v1.1.0) per Data Services Versioning Standard §10. Merging this → release-please Release PR → tag v1.1.1 → CD (Production) deploy.

## What

App Engine scaling fixes to stop site-wide 500/503 outages:
- `app.template.yaml` — add `max_concurrent_requests: 6`
- `CD_production.yml` — `MIN_INSTANCES` `0` → `1`
- `CD_production.yml` — gunicorn `-w 4` → `-w 8`

## Why

Prod returned site-wide 500/503 including `/` and `/health`. Live logs (54-min window): **279/300 requests = 500 with blank `instanceId`** — killed in the App Engine pending queue, never reached app code. The 21 that reached the single instance = **100% 200, ~0.1s**. Only **1** instance ran despite `max_instances=10`. Not OOM (zero soft-memory-limit lines), not a code crash.

**Root cause:** scheduler had no visibility into per-instance concurrency (gunicorn `-w 4`), so under burst load (map UI firing many `?f=json&limit=10000` collection requests at once) it pinned everything to one saturated instance instead of scaling out.

## How the fixes address it

1. `max_concurrent_requests: 6` → explicit per-instance ceiling → scheduler scales out to the idle instance slots. Primary fix. Set below the 8 workers on purpose — 2-worker headroom absorbs bursts.
2. `MIN_INSTANCES=1` → kills cold-start pile-ups.
3. `-w 8` → doubles concurrency per F4 (1GB) instance.

## Reviewer notes

- Config-only; no app code touched.
- Cap 6 < 8 workers is intentional (scale-out headroom), not a typo.
- After v1.1.1 deploys, forward-merge.yml opens `hotfix/v1.1.1` → `production`; then run `forward-merge` (source_branch=production) to carry the fix to `staging`. Staging PR #753 can then be closed to avoid double-apply.
- Pre-existing pygeoapi SensorThings `KeyError: '@iot.id'` 500s in logs are unrelated and NOT addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)