### PR TITLE
fix(ci): pass release tag to CD_production in manifest mode

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,8 +15,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      # In manifest mode, release-please-action exposes the unprefixed
+      # `release_created` boolean but only a PATH-SCOPED `.--tag_name` (the
+      # unprefixed `tag_name` comes through empty). Fall back to the path-scoped
+      # key so the tag reaches CD_production; without it the deploy job's
+      # `startsWith(inputs.tag_name, 'v')` gate silently skips the release.
+      release_created: ${{ steps.release.outputs.release_created || steps.release.outputs['.--release_created'] }}
+      tag_name: ${{ steps.release.outputs.tag_name || steps.release.outputs['.--tag_name'] }}
     steps:
       # staging uses its own config/manifest pair: prerelease (rc) versioning,
       # separate changelog, and its own version state so the rc line never


### PR DESCRIPTION
## What

`release-please.yml` — resolve the release tag from release-please-action's **path-scoped** output (`.--tag_name`) with a fallback, so CD (Production) actually deploys.

```yaml
release_created: ${{ steps.release.outputs.release_created || steps.release.outputs['.--release_created'] }}
tag_name:        ${{ steps.release.outputs.tag_name        || steps.release.outputs['.--tag_name'] }}
```

## Why — production deploy silently skipped

During the v1.1.1 hotfix: release-please cut the release (tag `v1.1.1`, published) but **CD (Production) never ran**.

Trace of run [28806722930](https://github.com/DataIntegrationGroup/OcotilloAPI/actions/runs/28806722930):
- `deploy-production` caller job **invoked** the reusable `CD_production` workflow → so `release_created` was `true`.
- The inner `production-deploy` job **self-skipped** on its gate:
  ```yaml
  if: ${{ startsWith(inputs.tag_name || github.event.release.tag_name, 'v') }}
  ```
- `inputs.tag_name` arrived **empty** → `startsWith('', 'v') = false` → skip.

**Root cause:** `release-please-action@v5` in **manifest mode** exposes the unprefixed `release_created` boolean, but the tag only as the **path-scoped** `.--tag_name` — the unprefixed `tag_name` comes through empty. The job-output mapping read the empty unprefixed value, so CD_production got no tag.

Log confirms the release existed: `❯ Found release for path ., v1.1.1`.

## Effect

Without this, **every manifest-mode release silently skips the production deploy** — the release/tag are created but nothing ships. This is the general fix, not hotfix-specific.

## Reviewer notes

- CI-only; no app/deploy logic changed. CD_production's gate is left as-is — it passes once the tag is populated.
- Added the `.--release_created` fallback for symmetry (the unprefixed one currently works, but this future-proofs it).
- This branch is `staging`-based. It needs to reach `production` + the active `hotfix/v1.1.1` line via forward-merge so those release paths get the fix too.
- **Separate immediate action** (not this PR): deploy the already-cut `v1.1.1` by re-publishing the release (`gh release edit v1.1.1 --draft && gh release edit v1.1.1 --draft=false`) so the `release: published` path fires CD_production now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)