### PR TITLE
feat(api/search): add groups/projects to search

### DIFF
--- a/alembic/versions/y3z4a5b6c7d8_add_group_search_vector.py
+++ b/alembic/versions/y3z4a5b6c7d8_add_group_search_vector.py
@@ -12,7 +12,6 @@ import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op
 
-
 revision: str = "y3z4a5b6c7d8"
 down_revision: Union[str, None] = "e2f3a4b5c6d7"
 branch_labels: Union[str, Sequence[str], None] = None
@@ -35,17 +34,14 @@ def upgrade() -> None:
         unique=False,
         postgresql_using="gin",
     )
-    op.execute(
-        """
+    op.execute("""
         UPDATE "group"
         SET search_vector = to_tsvector(
             'pg_catalog.simple',
             concat_ws(' ', name, description, group_type)
         )
-        """
-    )
-    op.execute(
-        """
+        """)
+    op.execute("""
         CREATE TRIGGER "group_search_vector_update"
         BEFORE INSERT OR UPDATE ON "group"
         FOR EACH ROW EXECUTE PROCEDURE
@@ -56,8 +52,7 @@ def upgrade() -> None:
             'description',
             'group_type'
         )
-        """
-    )
+        """)
 
 
 def downgrade() -> None:

--- a/alembic/versions/y3z4a5b6c7d8_add_group_search_vector.py
+++ b/alembic/versions/y3z4a5b6c7d8_add_group_search_vector.py
@@ -1,0 +1,66 @@
+"""add group search vector
+
+Revision ID: y3z4a5b6c7d8
+Revises: e2f3a4b5c6d7
+Create Date: 2026-07-06 16:20:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+from alembic import op
+
+
+revision: str = "y3z4a5b6c7d8"
+down_revision: Union[str, None] = "e2f3a4b5c6d7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "group",
+        sa.Column(
+            "search_vector",
+            sqlalchemy_utils.types.ts_vector.TSVectorType(),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_group_search_vector",
+        "group",
+        ["search_vector"],
+        unique=False,
+        postgresql_using="gin",
+    )
+    op.execute(
+        """
+        UPDATE "group"
+        SET search_vector = to_tsvector(
+            'pg_catalog.simple',
+            concat_ws(' ', name, description, group_type)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER "group_search_vector_update"
+        BEFORE INSERT OR UPDATE ON "group"
+        FOR EACH ROW EXECUTE PROCEDURE
+        tsvector_update_trigger(
+            'search_vector',
+            'pg_catalog.simple',
+            'name',
+            'description',
+            'group_type'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute('DROP TRIGGER IF EXISTS "group_search_vector_update" ON "group"')
+    op.drop_index("ix_group_search_vector", table_name="group", postgresql_using="gin")
+    op.drop_column("group", "search_vector")

--- a/api/search.py
+++ b/api/search.py
@@ -16,7 +16,7 @@
 from fastapi import APIRouter
 from fastapi_pagination import paginate
 from fastapi_pagination.utils import disable_installed_extensions_check
-from sqlalchemy import select, func, text, or_
+from sqlalchemy import select, func, text
 from sqlalchemy.orm import Session, selectinload
 
 from api.pagination import CustomPage
@@ -203,23 +203,15 @@ def _get_asset_results(session: Session, q: str, limit: int) -> list[dict]:
 
 
 def _get_project_results(session: Session, q: str, limit: int) -> list[dict]:
-    search_term = f"%{q.strip()}%"
-    query = (
-        select(Group)
-        .where(
-            or_(
-                Group.name.ilike(search_term),
-                Group.description.ilike(search_term),
-                Group.group_type.ilike(search_term),
-            )
-        )
-        .order_by(Group.name)
-        .limit(limit)
-        .options(
+    query = search(
+        select(Group).options(
             selectinload(Group.thing_associations).selectinload(
                 GroupThingAssociation.thing
             )
-        )
+        ),
+        q,
+        vector=Group.search_vector,
+        limit=limit,
     )
 
     projects = session.scalars(query).all()

--- a/api/search.py
+++ b/api/search.py
@@ -16,11 +16,12 @@
 from fastapi import APIRouter
 from fastapi_pagination import paginate
 from fastapi_pagination.utils import disable_installed_extensions_check
-from sqlalchemy import select, func, text
+from sqlalchemy import select, func, text, or_
 from sqlalchemy.orm import Session, selectinload
 
 from api.pagination import CustomPage
 from core.dependencies import session_dependency, viewer_dependency
+from services.group_helper import get_well_counts_by_group_id
 from db import (
     Contact,
     Email,
@@ -32,6 +33,8 @@ from db import (
     WellPurpose,
     Asset,
     AssetThingAssociation,
+    Group,
+    GroupThingAssociation,
     search,
 )
 
@@ -86,10 +89,13 @@ def _get_contact_results(session: Session, q: str, limit: int) -> list[dict]:
 
 
 def _get_thing_results(session: Session, q: str, limit: int) -> list[dict]:
+    empty = text("''::tsvector")
+    casing_vector = func.coalesce(WellCasingMaterial.search_vector, empty)
+    purpose_vector = func.coalesce(WellPurpose.search_vector, empty)
     well_vector = (
-        func.coalesce(Thing.search_vector, text("''::tsvector"))
-        .op("||")(func.coalesce(WellCasingMaterial.search_vector, text("''::tsvector")))
-        .op("||")(func.coalesce(WellPurpose.search_vector, text("''::tsvector")))
+        func.coalesce(Thing.search_vector, empty)
+        .op("||")(casing_vector)
+        .op("||")(purpose_vector)
     )
 
     water_well_query = search(
@@ -196,6 +202,52 @@ def _get_asset_results(session: Session, q: str, limit: int) -> list[dict]:
     return results
 
 
+def _get_project_results(session: Session, q: str, limit: int) -> list[dict]:
+    search_term = f"%{q.strip()}%"
+    query = (
+        select(Group)
+        .where(
+            or_(
+                Group.name.ilike(search_term),
+                Group.description.ilike(search_term),
+                Group.group_type.ilike(search_term),
+            )
+        )
+        .order_by(Group.name)
+        .limit(limit)
+        .options(
+            selectinload(Group.thing_associations).selectinload(
+                GroupThingAssociation.thing
+            )
+        )
+    )
+
+    projects = session.scalars(query).all()
+    well_counts = get_well_counts_by_group_id(
+        session, [project.id for project in projects]
+    )
+    results = [
+        {
+            "label": project.name,
+            "group": "Projects",
+            "properties": {
+                "id": project.id,
+                "description": project.description,
+                "group_type": project.group_type,
+                "parent_group_id": project.parent_group_id,
+                "well_count": well_counts.get(project.id, 0),
+                "things": [
+                    {"label": t.name, "id": t.id, "thing_type": t.thing_type}
+                    for t in project.things
+                ],
+            },
+        }
+        for project in projects
+    ]
+
+    return results
+
+
 @router.get("")
 def search_api(
     user: viewer_dependency,
@@ -211,6 +263,7 @@ def search_api(
     results = _get_contact_results(session, q, limit)
     results.extend(_get_thing_results(session, q, limit))
     results.extend(_get_asset_results(session, q, limit))
+    results.extend(_get_project_results(session, q, limit))
 
     return paginate(results)
     # return {"items": results, "total": len(results)}

--- a/db/group.py
+++ b/db/group.py
@@ -19,6 +19,7 @@ from geoalchemy2 import Geometry, WKBElement
 from sqlalchemy import String, Integer, ForeignKey, UniqueConstraint
 from sqlalchemy.ext.associationproxy import association_proxy, AssociationProxy
 from sqlalchemy.orm import relationship, Mapped, mapped_column
+from sqlalchemy_utils import TSVectorType
 
 from core.constants import SRID_WGS84
 from db.base import Base, AutoBaseMixin, ReleaseMixin, lexicon_term
@@ -36,6 +37,9 @@ class Group(Base, AutoBaseMixin, ReleaseMixin):
         Geometry(geometry_type="MULTIPOLYGON", srid=SRID_WGS84, spatial_index=True)
     )
     group_type: Mapped[Optional[str]] = lexicon_term(nullable=True)
+    search_vector: Mapped[TSVectorType] = mapped_column(
+        TSVectorType("name", "description", "group_type")
+    )
 
     # Foreign Keys
     parent_group_id: Mapped[Optional[int]] = mapped_column(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -79,6 +79,33 @@ def test_search_api(
     ]
 
 
+def test_search_api_projects(group, water_well_thing):
+    response = client.get("/search", params={"q": "Test Group"})
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, dict)
+    items = data.get("items")
+    assert isinstance(items, list)
+
+    project_items = [item for item in items if item["group"] == "Projects"]
+    assert len(project_items) == 1
+    project_item = project_items[0]
+    assert project_item["label"] == group.name
+    assert project_item["properties"]["id"] == group.id
+    assert project_item["properties"]["description"] == group.description
+    assert project_item["properties"]["group_type"] == group.group_type
+    parent_group_id = project_item["properties"]["parent_group_id"]
+    assert parent_group_id == group.parent_group_id
+    assert project_item["properties"]["well_count"] == 1
+    assert project_item["properties"]["things"] == [
+        {
+            "label": water_well_thing.name,
+            "id": water_well_thing.id,
+            "thing_type": water_well_thing.thing_type,
+        },
+    ]
+
+
 @pytest.mark.skip(reason="This test is not working .")
 def test_search_api2():
     response = client.get("/search", params={"q": "riochama"})


### PR DESCRIPTION
### **Why**
_This PR addresses the following problem/context:_
- Adds projects/groups to the global search results.
- Improves search performance for projects by introducing a PostgreSQL full-text search vector.

### **How**
_Implementation summary - the following was changed/added/removed:_
- Added a `search_vector` field to the Group model using `TSVectorType`.
- Added a database migration to create a `search_vector` column for the `group` table, backfill existing records, create a GIN index, and register a trigger to keep the search vector up to date.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- The PostgreSQL trigger automatically maintains the search vector on future inserts and updates.
