### PR TITLE
fix(ci): deploy on inline workflow_call to CD (Production)

### DIFF
--- a/.github/workflows/CD_production.yml
+++ b/.github/workflows/CD_production.yml
@@ -26,13 +26,16 @@ jobs:
     # (v*.*.*, v*.*.*-*, v*.*.*[a-z]*). startsWith() is a cheap pre-filter;
     # the "Validate release tag" step enforces the strict regex. The tag comes
     # from the workflow_call input or, for the release event, the payload.
-    if: ${{ startsWith((github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name, 'v') }}
+    # NOTE: a called workflow inherits the CALLER's event context, so
+    # github.event_name is never 'workflow_call' here — inputs.tag_name is
+    # simply empty when triggered by a release event, so `||` falls through.
+    if: ${{ startsWith(inputs.tag_name || github.event.release.tag_name, 'v') }}
 
     runs-on: ubuntu-latest
     environment: production
 
     env:
-      DEPLOY_TAG: ${{ (github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name }}
+      DEPLOY_TAG: ${{ inputs.tag_name || github.event.release.tag_name }}
 
     steps:
       - name: Validate release tag matches version pattern


### PR DESCRIPTION
## Problem
Merging a hotfix release PR cut the tag + GitHub release and invoked `CD_production.yml` inline via `workflow_call`, but the `production-deploy` job **skipped every time** — production was never deployed from the hotfix flow.

## Root cause
A called (reusable) workflow inherits the **caller's** event context. The caller (`release-please.yml` → `deploy-production`) is triggered by `push`, so inside `CD_production.yml` `github.event_name == 'push'`, **never** `'workflow_call'`. The gate:

```yaml
if: ${{ startsWith((github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name, 'v') }}
```

evaluates `('push'=='workflow_call' && …)` → false → falls to `github.event.release.tag_name`, empty on a push → `startsWith('', 'v')` → **false → skip**. Release-*event* deploys worked because that path populates `github.event.release.tag_name`; the inline `workflow_call` path never did.

Verified on run [28826087893](https://github.com/DataIntegrationGroup/OcotilloAPI/actions/runs/28826087893) (merge of release PR #763): `release-please` succeeded and cut `v1.1.3`, the reusable workflow instantiated (outer `release_created` gate passed), and `production-deploy` was `skipped`.

## Fix
Gate on `inputs.tag_name` directly — empty on the release path so `||` still falls through to the release payload. Correct for both trigger paths. **This is the same fix already live on `staging`.**

Merging this (a `fix:` commit) will have release-please open a **v1.1.4** release PR; merging that deploys via the now-working inline path — shipping the stuck hotfix code without a risky re-publish of v1.1.3 (whose code predates staging's renamed `refresh-materialized-views` CLI / pg_cron / Secret Manager steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)