### PR TITLE
fix(ci): deploy on inline workflow_call to CD (Production)

### DIFF
--- a/.github/workflows/CD_production.yml
+++ b/.github/workflows/CD_production.yml
@@ -26,13 +26,16 @@ jobs:
     # (v*.*.*, v*.*.*-*, v*.*.*[a-z]*). startsWith() is a cheap pre-filter;
     # the "Validate release tag" step enforces the strict regex. The tag comes
     # from the workflow_call input or, for the release event, the payload.
-    if: ${{ startsWith((github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name, 'v') }}
+    # NOTE: a called workflow inherits the CALLER's event context, so
+    # github.event_name is never 'workflow_call' here — inputs.tag_name is
+    # simply empty when triggered by a release event, so `||` falls through.
+    if: ${{ startsWith(inputs.tag_name || github.event.release.tag_name, 'v') }}
 
     runs-on: ubuntu-latest
     environment: production
 
     env:
-      DEPLOY_TAG: ${{ (github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name }}
+      DEPLOY_TAG: ${{ inputs.tag_name || github.event.release.tag_name }}
 
     steps:
       - name: Validate release tag matches version pattern


### PR DESCRIPTION
Companion to #765, for the `production` branch's copy of `CD_production.yml`.

## Root cause
A reusable workflow inherits the **caller's** event context. `release-please.yml` → `deploy-production` is triggered by `push`, so inside `CD_production.yml` `github.event_name == 'push'`, never `'workflow_call'`. The gate

```yaml
if: ${{ startsWith((github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name, 'v') }}
```

fell through to `github.event.release.tag_name` (empty on a push) → `production-deploy` skipped on every inline deploy. Only release-event deploys worked.

## Fix
Gate on `inputs.tag_name` directly (empty on the release path, so `||` still falls through). Same fix already live on `staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)