### PR TITLE
fix(ci): backport CD (Production) deploy-gate fix in hotfix-start

### DIFF
--- a/.github/workflows/hotfix-start.yml
+++ b/.github/workflows/hotfix-start.yml
@@ -72,6 +72,26 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "${{ steps.next.outputs.branch }}" "${{ steps.base.outputs.tag }}"
+
+          # Backport the CD (Production) inline-deploy gate fix. Tags cut before
+          # the fix carry a gate keyed on `github.event_name == 'workflow_call'`,
+          # which is NEVER true inside a called workflow (it inherits the
+          # caller's `push` event), so release-please's inline deploy silently
+          # skips `production-deploy` and the hotfix never ships. Rewrite the
+          # gate to key on `inputs.tag_name` (empty on the release path, so `||`
+          # still falls through). SURGICAL edit only — do not copy the whole
+          # file from the default branch, whose deploy steps may not match this
+          # tag's code.
+          f=.github/workflows/CD_production.yml
+          if [ -f "$f" ] && grep -qF "github.event_name == 'workflow_call'" "$f"; then
+            sed -i "s#(github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name#inputs.tag_name || github.event.release.tag_name#g" "$f"
+            git add "$f"
+            git commit -m "ci: backport CD (Production) inline-deploy gate fix"
+            echo "Backported CD (Production) deploy-gate fix onto ${{ steps.next.outputs.branch }}."
+          else
+            echo "CD (Production) deploy gate already current; no backport needed."
+          fi
+
           git push origin "${{ steps.next.outputs.branch }}"
 
       - name: Summary


### PR DESCRIPTION
Third of three PRs fixing the "hotfix merge doesn't deploy production" bug (see #765 hotfix/v1.1.3, #766 production).

## Why this one
`hotfix-start.yml` seeds a hotfix branch with `git checkout -b <branch> <tag>`, so the branch inherits `CD_production.yml` **as it was at that tag**. Every existing `v1.1.x` tag predates the deploy-gate fix, so any future hotfix cut from them reinherits the broken gate:

```yaml
if: ${{ startsWith((github.event_name == 'workflow_call' && inputs.tag_name) || github.event.release.tag_name, 'v') }}
```

`github.event_name` is never `'workflow_call'` inside a called workflow (it inherits the caller's `push`), so `production-deploy` skips on the inline path and the hotfix never ships.

## Fix
After creating the branch, surgically `sed`-rewrite the gate (and `DEPLOY_TAG`) to key on `inputs.tag_name`. **Surgical only** — deliberately *not* copying the whole file from the default branch, whose deploy steps have diverged from older tags' code (renamed `refresh-materialized-views` CLI, pg_cron, Secret Manager fetch) and would break the deploy. Idempotent: skips cleanly when the gate is already current.

Committed as `ci:` so it doesn't cut a standalone release-please release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)