### PR TITLE
fix(deploy): propagate F4_1G instance class to staging + OOM writeup

### DIFF
--- a/.github/app.template.yaml
+++ b/.github/app.template.yaml
@@ -2,7 +2,13 @@ service: ${SERVICE_NAME}
 runtime: python313
 entrypoint: ${ENTRYPOINT}
 service_account: "${CLOUD_SQL_USER}.gserviceaccount.com"
-instance_class: F4
+# F4_1G (2 GB) not F4 (1 GB): production runs gunicorn -w 8, and eight workers
+# each importing the full stack (sqlalchemy + geoalchemy2 + shapely + cloud-sql
+# connector + pygeoapi) exceeded 1 GB, so App Engine terminated processes for
+# "using too much memory" and cycled workers continuously, cold-loading every
+# request. See docs/app-engine-oom-instance-churn.md. Shipped to prod in v1.1.5;
+# this propagates the same class to staging/testing to prevent regression.
+instance_class: F4_1G
 inbound_services:
   - warmup
 automatic_scaling:

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ cli/logs
 .pygeoapi/
 # deployment files
 app.yaml
-docs/
 
 #Codex
 .codex

--- a/docs/app-engine-oom-instance-churn.md
+++ b/docs/app-engine-oom-instance-churn.md
@@ -1,0 +1,153 @@
+# App Engine OOM Instance Churn — Degradation and Fix
+
+## Summary
+
+On 2026-07-07 the production App Engine service `ocotillo-api` served **every**
+request slowly, even at low traffic. The application was not returning errors —
+requests eventually succeeded — but latency was uniformly high because the
+single serving instance was being killed and restarted continuously. Each
+request therefore tended to land on a process that was still cold-loading the
+application.
+
+The cause was memory exhaustion introduced by the previous scaling fix (see
+[`app-engine-request-starvation.md`](app-engine-request-starvation.md)), which
+raised the Gunicorn worker count from 4 to 8. Eight workers did not fit in the
+F4 (1 GB) instance class. The fix raises the instance class to F4_1G (2 GB).
+
+This is the direct sequel to the request-starvation outage: that fix cured the
+scale-out failure but overshot on per-instance worker count for the instance's
+memory.
+
+## Symptoms
+
+- Uniformly slow responses on all routes, **independent of traffic volume** —
+  slow even when only one or two users were active.
+- Not an outage: requests returned `200`, just slowly. No site-wide `500`/`503`
+  (distinguishing this from the earlier starvation outage).
+- Presented as "the API cold-starts for every user."
+
+## Investigation
+
+Because `min_instances` was `1`, one instance should always have been warm, so
+uniform slowness at low traffic pointed at either (a) the warm instance
+recycling, or (b) genuinely slow per-request work.
+
+Per-request work was ruled out by reading `db/engine.py`: the SQLAlchemy engine
+and connection pool are created once at module import
+(`engine = init_connection_pool(connector)`) and reused across requests
+(`pool_pre_ping=True`, `echo=False`). Requests do not re-establish connections,
+so the slowness was not per-request connection setup.
+
+That left instance recycling. Cloud Logging confirmed it. An initial query for
+`"Exceeded soft memory limit"` returned nothing — that is the wrong phrase for
+the App Engine **standard** environment. The correct signal is the message
+below.
+
+### Evidence (production, 3-hour window)
+
+- **44** requests logged: *"the process that handled this request was found to
+  be using too much memory and was terminated ... Consider setting a larger
+  instance class in app.yaml."*
+- **304** `Booting worker` lines — Gunicorn workers restarting continuously.
+- **297** `SIGTERM` / **297** `was sent` — App Engine killing over-memory
+  processes.
+- **334** `shutting down` — instance/worker shutdown churn.
+- Multiple *"This request caused a new process to be started ... loaded for the
+  first time"* lines — cold loading requests hitting users directly.
+- Live serving version confirmed as instance class **F4**, one instance,
+  100% traffic.
+
+A worker was being killed for memory roughly every four minutes, so the
+"always-on" instance was effectively always cold.
+
+## Root cause
+
+The production entrypoint runs:
+
+```
+gunicorn -w 8 -k uvicorn.workers.UvicornWorker main:app
+```
+
+on instance class **F4 (1 GB)**. Each of the eight worker processes imports the
+full application stack independently — SQLAlchemy, GeoAlchemy2, Shapely, the
+Cloud SQL Python connector, and pygeoapi — with no `--preload`, so there is no
+copy-on-write sharing between workers. Eight independent copies of that stack
+exceeded 1 GB, so App Engine terminated worker processes for using too much
+memory and started new ones, indefinitely.
+
+The prior request-starvation fix deliberately raised `-w 4` → `-w 8` for more
+per-instance throughput. On its own that change was reasonable, but it was not
+paired with more memory, and 8 workers do not fit in F4.
+
+## Fix
+
+One change, deployment configuration only (`.github/app.template.yaml`):
+
+```yaml
+instance_class: F4_1G   # was F4
+```
+
+F4_1G provides 2 GB (same 2.4 GHz class), which comfortably holds eight workers
+and their imports. This follows App Engine's own remediation message
+("Consider setting a larger instance class").
+
+The change deliberately preserves the scale-out tuning from the starvation fix
+— `gunicorn -w 8`, `max_concurrent_requests: 6`, `min_instances: 1`,
+`max_instances: 10` — so the earlier `500`/`503` starvation cannot recur.
+
+### Alternatives considered
+
+- **Reduce workers (`-w 8` → `-w 4`).** Would cut memory ~half at no cost, but
+  requires also lowering `max_concurrent_requests` to stay at or below the
+  worker count; otherwise the request-starvation failure returns. Retunes the
+  balance the prior fix set. Rejected in favor of the lower-risk memory bump.
+- **Add `--preload`.** Would share imports across forked workers, but the
+  module-level SQLAlchemy engine / Cloud SQL `Connector` is created at import,
+  and sharing a pool across forked processes is unsafe without a post-fork
+  `engine.dispose()`. Not a one-line hotfix; rejected.
+
+### Shared template note
+
+`app.template.yaml` renders for all environments. Staging and testing run
+`-w 4` and scale to zero (`MIN_INSTANCES=0`), so raising their class to F4_1G
+grants harmless headroom at negligible idle cost. If per-environment instance
+classes become desirable, template `instance_class` as `${INSTANCE_CLASS}` and
+export it from each `CD_*` workflow, mirroring `MIN_INSTANCES` / `ENTRYPOINT`.
+
+## Verification
+
+After deploying `v1.1.5`, confirm on the live version:
+
+```bash
+gcloud app versions list --service=ocotillo-api \
+  --project=waterdatainitiative-271000 \
+  --hide-no-traffic --format='value(id, version.instanceClass)'
+# expect: <version>  F4_1G
+```
+
+and confirm the over-memory terminations stop:
+
+```bash
+gcloud logging read \
+  'resource.type="gae_app" AND resource.labels.module_id="ocotillo-api"
+   AND "using too much memory"' \
+  --project=waterdatainitiative-271000 --freshness=1h --format='value(timestamp)'
+# expect: no results after the new version takes traffic
+```
+
+Request latency should drop to the warm-path baseline (~0.1 s for light
+endpoints) once workers stop cycling.
+
+## Tuning notes
+
+- The correct App Engine **standard** memory-kill phrase for log searches is
+  *"using too much memory and was terminated"*, **not** *"Exceeded soft memory
+  limit"* (which is flex-environment wording). Searching the wrong phrase
+  returns a false all-clear.
+- Keep `max_concurrent_requests` (6) at or below the Gunicorn worker count (8);
+  see the starvation doc for why.
+- If memory again becomes tight after future dependency growth, the next levers
+  are `--preload` with a post-fork pool dispose, or reducing worker count with a
+  matching `max_concurrent_requests` reduction — before jumping another instance
+  class.
+```

--- a/docs/geoserver-architecture-2026-05-18.md
+++ b/docs/geoserver-architecture-2026-05-18.md
@@ -1,0 +1,81 @@
+# GeoServer Architecture Snapshot (2026-05-18)
+
+## System Context
+```mermaid
+graph LR
+    subgraph Operators
+      OP1[AEM Ingest Operator]
+      OP2[Platform/Infra Maintainer]
+      OP3[GIS Consumer]
+    end
+
+    subgraph OcotilloAPI Repo Runtime
+      BATCH[services/aem_batch.py]
+      INGEST[services/aem_asset_ingest.py]
+      PUB[services/geoserver_helper.py]
+      STAC[services/aem_stac.py]
+      OGC[FastAPI + mounted pygeoapi /ogcapi]
+      DB[(PostgreSQL + PostGIS)]
+    end
+
+    subgraph GeoServer Stack
+      LB[HTTPS Load Balancer]
+      GS[GeoServer Container]
+      REST[GeoServer REST API]
+    end
+
+    subgraph Storage
+      GCS[(GCS Buckets)]
+      MNT[Mounted filesystem path]
+    end
+
+    OP1 --> BATCH
+    OP1 --> INGEST
+
+    BATCH --> GCS
+    INGEST --> GCS
+    BATCH --> PUB
+    INGEST --> PUB
+    PUB --> REST
+    PUB --> DB
+
+    STAC --> DB
+    STAC --> LB
+
+    OP3 --> LB
+    OP3 --> OGC
+
+    GCS --> MNT
+    MNT --> GS
+    LB --> GS
+    GS --> DB
+
+    OP2 --> LB
+    OP2 --> GS
+```
+
+## Main Runtime Flows
+
+### 1. GeoTIFF publish flow
+1. AEM ingest uploads GeoTIFF to GCS.
+2. AEM ingest/batch invokes GeoServer publisher helper.
+3. Publisher resolves mounted source path and calls GeoServer REST.
+4. Publisher updates asset publish tracking fields in DB.
+
+### 2. STAC service-link flow
+1. STAC collection payload is built.
+2. If GeoServer env vars are set, collection assets include WMS/WFS/WCS links.
+3. GIS clients discover GeoServer endpoints via those links.
+
+### 3. Current hybrid serving flow
+1. OGC API Features remains on mounted pygeoapi under /ogcapi.
+2. GeoServer handles AEM raster publication and related OWS exposure.
+
+## Deployment Topology (Defined in IaC)
+- GCP VM + instance group + HTTPS load balancer.
+- Startup script installs docker and gcsfuse, mounts bucket paths, runs GeoServer container.
+- Domain front door configured for https://geoserver.newmexicowaterdata.org/geoserver.
+
+## Boundary Clarification
+- OcotilloAPI remains the primary app/API process for core REST and pygeoapi-backed OGC Features.
+- GeoServer is currently a specialized publishing tier for AEM-oriented map/coverage/feature service surfaces.

--- a/docs/geoserver-current-state-analysis-2026-05-18.md
+++ b/docs/geoserver-current-state-analysis-2026-05-18.md
@@ -1,0 +1,137 @@
+# GeoServer Current State Analysis (2026-05-18)
+
+## Scope
+This is a current-state snapshot of GeoServer-related implementation and operations in this repository. All work described here lives on the `geophysical/poc` branch.
+
+## Companion Doc
+- Architecture diagram: docs/geoserver-architecture-2026-05-18.md
+
+## 1) Current Purpose of GeoServer
+GeoServer currently appears to serve as a dedicated geospatial publishing tier for AEM raster and service-link use cases, while the main Ocotillo OGC feature API is still served by mounted pygeoapi under /ogcapi.
+
+Evidence:
+- ADR states pygeoapi remains active for /ogcapi and GeoServer is the strategic direction for public geospatial delivery (ADR is still marked Proposed and partially superseded).
+- AEM ingest/batch code publishes validated GeoTIFF assets to GeoServer via REST (workspace + coverage store registration).
+- STAC collection builders can emit GeoServer WMS/WFS/WCS links when GeoServer env vars are configured.
+
+Net: GeoServer is in active support for AEM publishing workflows, but it is not yet the sole or primary geospatial interface in app runtime because pygeoapi still serves the OGC API feature surface.
+
+## 2) Components That Exist Today
+
+### Application-side components
+- GeoServer publisher helper:
+  - services/geoserver_helper.py
+  - Handles:
+    - config via GEOSERVER_URL, GEOSERVER_USERNAME, GEOSERVER_PASSWORD
+    - idempotent workspace/store handling
+    - external GeoTIFF registration using GeoServer REST endpoint
+    - publish status tracking payloads
+- AEM asset ingest integration:
+  - services/aem_asset_ingest.py
+  - Invokes publish_geotiff_asset for validated AEM GeoTIFFs.
+- AEM batch orchestration:
+  - services/aem_batch.py
+  - Routes geotiff records through upload + GeoServer publish attempt.
+- STAC asset link generation:
+  - services/aem_stac.py
+  - Adds optional survey-level WMS/WFS/WCS links when GEOSERVER_PUBLIC_URL and GEOSERVER_WORKSPACE are set.
+
+### Data model and migration support
+- Asset publish tracking fields exist in DB model:
+  - db/asset.py
+  - publish_target, publish_status, publish_workspace, publish_store_name, publish_layer_name, publish_last_attempt_at, publish_last_error
+- Migration that added those fields:
+  - alembic/versions/u1v2w3x4y5z6_add_asset_publish_tracking_columns.py
+
+### Testing coverage
+- GeoServer publisher unit tests:
+  - tests/test_geoserver_helper.py
+  - Covers: create missing workspace/store, idempotency, failure recording, missing source root error handling
+- AEM ingest tests verifying publish state persistence:
+  - tests/test_aem_asset_ingest.py
+- STAC tests for GeoServer collection assets:
+  - tests/test_aem.py (GeoServer WMS/WFS/WCS asset expectations)
+
+### Infrastructure / deployment components
+- Terraform module for standalone GeoServer stack:
+  - geoserver_iac/main.tf
+  - geoserver_iac/variables.tf
+  - geoserver_iac/outputs.tf
+  - geoserver_iac/versions.tf
+  - geoserver_iac/startup-geoserver.sh.tpl
+- Provisioning pattern:
+  - GCP VM instance + instance group
+  - HTTPS load balancer with managed certificate and health checks
+  - Startup script installs docker + gcsfuse, mounts GCS bucket(s), runs GeoServer container
+- Container image pin:
+  - docker.osgeo.org/geoserver:2.28.0
+
+## 3) Rough Existing Data Flows
+
+### Flow A: AEM GeoTIFF ingest -> GeoServer publish
+1. AEM batch/run ingests file metadata and uploads GeoTIFF to GCS.
+2. Asset metadata record is created or updated.
+3. GeoServer helper resolves mounted filesystem source path from GEOSERVER_RASTER_SOURCE_ROOT + storage path.
+4. GeoServer helper ensures workspace exists.
+5. GeoServer helper checks for existing coverage store; if absent, registers external GeoTIFF.
+6. Publish result is persisted to asset publish_* tracking columns.
+
+### Flow B: STAC collection generation -> GeoServer service links
+1. AEM STAC collection is built.
+2. If GEOSERVER_PUBLIC_URL and GEOSERVER_WORKSPACE are set, collection assets include:
+   - WMS GetCapabilities
+   - WFS GetFeature
+   - WCS DescribeCoverage
+3. Resulting links point clients to GeoServer OWS endpoints.
+
+### Flow C: Parallel geospatial serving mode (current)
+1. Main API still serves OGC API Features under /ogcapi using pygeoapi.
+2. GeoServer is used for AEM GeoTIFF publication and optional STAC map/feature/coverage links.
+3. This implies a hybrid platform state (pygeoapi + GeoServer).
+
+## 4) Known Basic Use Cases and Users
+
+### Supported use cases (known)
+- Publish validated AEM GeoTIFFs to GeoServer during batch ingest.
+- Track publication outcomes per asset (success/failed/skipped/disabled).
+- Provide GeoServer WMS/WFS/WCS links in STAC collections for AEM datasets.
+- Serve GeoServer through public HTTPS endpoint (domain configured in Terraform vars).
+
+### Likely user groups (inferred from code/docs)
+- Data engineering / ingestion operators running AEM batch and single-file ingest.
+- GIS/data consumers using WMS/WFS/WCS endpoints linked from STAC artifacts.
+- Platform/infra maintainers operating GCP/Terraform deployment for GeoServer.
+
+### Not shown as implemented in repo
+- Full replacement of /ogcapi feature APIs by GeoServer.
+- GeoServer workspace/layer/style lifecycle as code (beyond runtime REST publication in ingest path).
+- End-user UI workflows in Ocotillo admin for GeoServer management.
+
+## 5) How It Is Deployed (As Implemented)
+- Infra-as-code in geoserver_iac deploys a dedicated GCP VM-based stack.
+- VM startup script:
+  - installs docker and gcsfuse
+  - mounts configured GCS bucket prefixes (GeoServer data and optional surveys)
+  - runs GeoServer container on 8080 with proxy base URL set to https://<domain>/geoserver
+- HTTPS load balancer fronts VM instance group and health-checks /geoserver/index.html.
+- Terraform backend uses GCS state bucket/prefix.
+
+### GCS as GeoServer data source of truth
+GeoServer configuration state (workspaces, stores, layers, styles) is not stored on ephemeral container or VM disk. It is persisted in GCS and mounted into the container via gcsfuse:
+
+- **Data directory bucket** (`geoserver_data_bucket`): mounted r/w at host path `geoserver_data_mount_point` (default `/mnt/disks/geoserver-data`), scoped to prefix `geoserver_data_only_dir` (default `data_dir`), then bind-mounted into the container at `/opt/geoserver_data`. This bucket is the authoritative source of truth for GeoServer config.
+- **Surveys bucket** (`surveys_bucket`, optional): mounted read-only at host path `surveys_mount_point` (default `/mnt/disks/geoserver-surveys`) and exposed inside the container at `surveys_container_mount_point` (default `/opt/geoserver_data/surveys`). Used for GeoServer raster asset access.
+
+VM service account (`geoserver-vm`) is granted `roles/storage.objectViewer` on both buckets via IAM resources in main.tf. GCS object versioning is the implicit backup mechanism for GeoServer config, but whether versioning is enabled on the live bucket is unknown.
+
+
+## 6) Unknowns / Gaps Captured
+- **Partially known**: Source of truth for GeoServer config is `geoserver_data_bucket` (GCS, mounted via gcsfuse — see section 5). Unknown: which specific bucket is live in production, and whether workspace/layer/style writes originate from admin UI or REST API calls.
+- Unknown authn/authz posture for GeoServer admin/API and public endpoints (beyond LB exposure and SSH admin CIDR).
+- Unknown SLOs, observability dashboards, alerting, and incident ownership for GeoServer service.
+- **Partially known**: GeoServer config backup relies on GCS object versioning on `geoserver_data_bucket`. Unknown: whether versioning is enabled, what retention policy exists, and whether a restore drill has been performed.
+- Unknown rollout status of ADR recommendation to make GeoServer the primary delivery tier.
+- Unknown whether IaC in geoserver_iac is fully in sync with deployed infra (state file in repo is non-authoritative and mixed local artifacts exist).
+
+## 7) Current-State Conclusion
+GeoServer is implemented and integrated enough to support AEM raster publication and downstream service-link generation, with a dedicated GCP deployment path defined in Terraform. However, the primary OGC feature API in this application remains pygeoapi-based, so current architecture is hybrid rather than fully GeoServer-centric. The largest unknowns are operational governance (config-as-code, ownership, observability, security controls) and the true production cutover status.

--- a/docs/geoserver-current-state-doc-2026-05-18.md
+++ b/docs/geoserver-current-state-doc-2026-05-18.md
@@ -1,0 +1,98 @@
+# GeoServer Current State Documentation
+
+**Prepared by:** Jake Ross
+**Date:** 2026-05-18
+**Meeting / source:** geophysical/poc branch — code review + IaC analysis
+
+---
+
+**Purpose.** Capture the current state of GeoServer integration in plain language: what it is, how data moves through it, what is working, what is broken, and what decisions are still open.
+
+---
+
+## 1. Summary (Current State)
+
+GeoServer is a dedicated geospatial publishing tier integrated into the OcotilloAPI platform. It handles AEM raster (GeoTIFF) publication and exposes WMS/WFS/WCS service links for STAC collections. It runs as a Docker container on a GCP VM, backed by GCS buckets for persistent config and raster data. The primary OGC API feature surface (/ogcapi) still runs on pygeoapi, so the current architecture is hybrid — GeoServer handles rasters and OWS services, pygeoapi handles vector feature API. GeoServer also connects to PostGIS as a vector data store.
+
+---
+
+## 2. What Problem Does It Solve?
+
+- **Original problem:** No OGC-compliant raster tile/coverage service existed for AEM geophysical survey data being ingested into the platform.
+- **Current problem:** AEM GeoTIFF ingest pipeline needs a publish target that exposes WMS/WFS/WCS endpoints; STAC collection records need service links for map/feature/coverage consumers. GeoServer fills both roles.
+- **Primary users / consumers:**
+  - AEM ingest operators (run batch and single-file ingest that triggers GeoServer publish)
+  - GIS/data consumers (access WMS/WFS/WCS links embedded in STAC collection assets)
+  - Platform/infra maintainers (operate GCP + Terraform deployment)
+
+---
+
+## 3. Inputs / Outputs
+
+| Input | Ingestion Layer | Raw Data Storage | Transformation & Load | Clean Data Storage | Service |
+|---|---|---|---|---|---|
+| AEM GeoTIFF files | `services/aem_batch.py`, `services/aem_asset_ingest.py` | GCS (`surveys_bucket`) | `services/geoserver_helper.py` — registers external GeoTIFF as GeoServer coverage store via REST | GeoServer data dir in GCS (`geoserver_data_bucket`) | WMS / WCS via HTTPS LB (`geoserver.newmexicowaterdata.org`) |
+| PostGIS vector data | GeoServer admin / REST config | PostgreSQL + PostGIS DB | GeoServer PostGIS data store connection | GeoServer workspace / layer config in GCS data dir | WFS via HTTPS LB |
+| STAC collection build | `services/aem_stac.py` | PostgreSQL (asset + survey records) | Generates WMS/WFS/WCS hrefs from `GEOSERVER_PUBLIC_URL` + `GEOSERVER_WORKSPACE` | STAC JSON artifact | STAC collection served by OcotilloAPI |
+
+---
+
+## 4. Main Components
+
+| Component | Role today | Owner / repo | Status |
+|---|---|---|---|
+| `services/geoserver_helper.py` | Idempotent GeoServer REST publish helper — workspace + coverage store registration, publish status tracking | OcotilloAPI / geophysical/poc | Active |
+| `services/aem_asset_ingest.py` | Single-file AEM ingest — invokes publish_geotiff_asset | OcotilloAPI / geophysical/poc | Active |
+| `services/aem_batch.py` | Batch AEM orchestration — routes GeoTIFFs through upload + GeoServer publish | OcotilloAPI / geophysical/poc | Active |
+| `services/aem_stac.py` | STAC service-link generation — adds WMS/WFS/WCS hrefs to collection assets | OcotilloAPI / geophysical/poc | Active |
+| `db/asset.py` publish fields | DB tracking for publish outcome per asset (`publish_status`, `publish_layer_name`, etc.) | OcotilloAPI / geophysical/poc | Active |
+| `geoserver_iac/` | Terraform IaC — GCP VM + instance group + HTTPS LB + gcsfuse bucket mounts | OcotilloAPI / geophysical/poc | Defined; live state unknown |
+| GeoServer container | `docker.osgeo.org/geoserver:2.28.0` running on GCP VM | GCP / geoserver_iac | Assumed active; not confirmed |
+| GCS `geoserver_data_bucket` | Source of truth for GeoServer config (workspaces, stores, layers, styles) — gcsfuse r/w mount at `/opt/geoserver_data` | GCP | Active; bucket name unknown |
+| GCS `surveys_bucket` | Raster source data for GeoServer coverage stores — gcsfuse r/o mount at `/opt/geoserver_data/surveys` | GCP | Active; bucket name unknown |
+| PostgreSQL + PostGIS | Vector data store — GeoServer connects directly for WFS feature serving | OcotilloAPI DB | Active |
+| HTTPS Load Balancer | Public front door for GeoServer at `geoserver.newmexicowaterdata.org/geoserver` | GCP / geoserver_iac | Defined in IaC |
+
+---
+
+## 5. Key Behavior
+
+**Flow A — AEM GeoTIFF publish:**
+1. Ingest uploads GeoTIFF to GCS (`surveys_bucket`).
+2. GeoServer helper resolves mounted path (`GEOSERVER_RASTER_SOURCE_ROOT` + storage path).
+3. Helper ensures workspace exists; registers external GeoTIFF as coverage store if absent.
+4. Publish outcome written to asset `publish_*` columns in DB.
+
+**Flow B — STAC service links:**
+1. STAC collection build reads asset + survey records from DB.
+2. If `GEOSERVER_PUBLIC_URL` and `GEOSERVER_WORKSPACE` are set, collection assets include WMS/WFS/WCS hrefs.
+3. GIS clients discover GeoServer endpoints via those links.
+
+**Flow C — Hybrid serving (current):**
+- `/ogcapi` OGC Features served by pygeoapi (unchanged).
+- GeoServer serves AEM raster publication and related OWS endpoints.
+- PostGIS vector data available to GeoServer as a data store alongside raster coverage stores.
+
+**Config persistence:**
+GeoServer data directory is gcsfuse-mounted from `geoserver_data_bucket` into the container at `/opt/geoserver_data`. All workspace/store/layer/style changes persist to GCS, not to ephemeral container disk.
+
+---
+
+## 6. Known Problems
+
+- No workspace/layer/style lifecycle as code — GeoServer config changes (e.g. new PostGIS data stores, style edits) go directly to GCS data dir via admin UI or REST, with no Git-backed review gate or promotion process.
+- IaC state is non-authoritative in the repo (`terraform.tfstate` is empty; `.tfstate.backup` is a stale local snapshot). True deployed state is unknown.
+- Hybrid serving architecture (pygeoapi + GeoServer) is unresolved — ADR recommending GeoServer as primary delivery tier is still marked Proposed.
+- No observability: no confirmed dashboards, alerts, or on-call ownership for GeoServer service health or publish failure rates.
+
+---
+
+## 7. Open Decisions / Questions
+
+- Which GCS buckets are the live `geoserver_data_bucket` and `surveys_bucket` in production?
+- Are workspace/store/layer writes happening via admin UI (writes to GCS data dir) or via REST API calls from code?
+- Is GCS object versioning enabled on `geoserver_data_bucket`? Has a restore drill been performed?
+- What is the current production traffic split between GeoServer OWS endpoints and pygeoapi /ogcapi?
+- What is the status of the ADR to make GeoServer the primary delivery tier — is there a timeline?
+- What is the authn/authz posture for the GeoServer admin endpoint and public OWS endpoints?
+- Who owns GeoServer incident response and what are the SLOs?

--- a/docs/geoserver-verification-checklist-2026-05-18.md
+++ b/docs/geoserver-verification-checklist-2026-05-18.md
@@ -1,0 +1,101 @@
+# GeoServer Verification Checklist (2026-05-18)
+
+Use this checklist to close the unknowns identified in the current-state analysis.
+
+## A. Production Usage Verification
+- [ ] Pull 30-day request logs for:
+  - GeoServer LB endpoint
+  - /ogcapi endpoints
+- [ ] Quantify request volume by endpoint family (WMS/WFS/WCS vs /ogcapi).
+- [ ] Identify top clients (service accounts, applications, external consumers).
+- [ ] Confirm which datasets are actively consumed from GeoServer vs pygeoapi.
+
+Evidence to capture:
+- URL and date range of logs queried.
+- Table of volumes by endpoint family.
+- Named systems consuming each interface.
+
+## B. GeoServer Configuration Governance
+
+**Known from IaC**: GeoServer data directory (workspaces, stores, layers, styles) is persisted in GCS and mounted into the container via gcsfuse at `/opt/geoserver_data`. The `geoserver_data_bucket` Terraform variable names the authoritative bucket; the `geoserver_data_only_dir` prefix (default `data_dir`) scopes the mount within that bucket. An optional second bucket (`surveys_bucket`) is mounted read-only at `/opt/geoserver_data/surveys` for raster asset access. The GCS buckets are therefore the source of truth for GeoServer configuration state — not the container filesystem and not a separate config-as-code repo.
+
+- [ ] Confirm which GCS bucket(s) are the live `geoserver_data_bucket` and `surveys_bucket` in production.
+- [ ] Confirm whether workspaces/stores/layers are created via admin UI writes (persisted to GCS through the mount) or via REST API calls from code.
+- [ ] Document whether changes are:
+  - API-driven from code,
+  - manual in admin UI (changes go directly to GCS data dir),
+  - imported from data directory snapshots.
+- [ ] Define promotion process across environments (dev/staging/prod).
+- [ ] Define review gate (PR, change ticket, approvals).
+
+Evidence to capture:
+- Bucket names for each environment.
+- Owner(s) and approver group.
+- Step-by-step promotion procedure.
+- Rollback procedure and tested example.
+
+## C. Security and Access Controls
+- [ ] Verify public exposure scope (only intended paths/services).
+- [ ] Verify GeoServer admin endpoint restrictions.
+- [ ] Verify credential rotation policy for GEOSERVER_USERNAME/PASSWORD.
+- [ ] Verify VM and container patch/update cadence.
+- [ ] Verify SSH access controls still match current admin roster.
+
+Evidence to capture:
+- Current access matrix (who can do what).
+- Rotation schedule and last rotation date.
+- Hardening checklist status.
+
+## D. Observability and Operations
+- [ ] Confirm logging coverage for publish attempts and failures.
+- [ ] Confirm alerts for:
+  - LB health-check failure
+  - GeoServer process/container down
+  - repeated publish failures
+- [ ] Confirm dashboards for latency/error rate/throughput.
+- [ ] Confirm incident ownership and escalation path.
+
+Evidence to capture:
+- Alert definitions and destinations.
+- Dashboard links.
+- On-call ownership mapping.
+
+## E. Data Resilience and Recovery
+
+**Known from IaC**: GeoServer config state lives in `geoserver_data_bucket` (gcsfuse mount). GCS object versioning or bucket-level backup policy is therefore the backup mechanism for GeoServer config — no separate data-directory backup step exists unless versioning is enabled on that bucket.
+
+- [ ] Confirm GCS versioning and/or object lifecycle policy on `geoserver_data_bucket`.
+- [ ] Confirm backup policy for GeoServer data directory (backed by GCS — see section B).
+- [ ] Confirm restore drill has been tested and documented.
+- [ ] Confirm RPO/RTO targets and current achieved posture.
+
+Evidence to capture:
+- Backup schedule and retention.
+- Last successful restore test date.
+- Recovery runbook location.
+
+## F. ADR/Cutover Status
+- [ ] Confirm current status of ADR3 recommendation in practice.
+- [ ] List datasets already migrated to GeoServer.
+- [ ] List datasets still on pygeoapi only.
+- [ ] Define explicit transition milestones and decision gates.
+
+Evidence to capture:
+- Dataset inventory by serving surface.
+- Owner and timeline for each migration wave.
+
+## G. IaC and Environment Consistency
+- [ ] Confirm Terraform state is authoritative and current for active environment.
+- [ ] Confirm repo IaC variables match deployed values (domain, buckets, mounts, image).
+- [ ] Remove ambiguity from local state artifacts in repo workflows.
+- [ ] Capture environment bootstrap steps needed for repeatable deploy.
+
+Evidence to capture:
+- Terraform state backend details and last apply metadata.
+- Drift report summary.
+- Environment parity table (desired vs actual).
+
+## Exit Criteria
+- [ ] Every checklist section has an owner and due date.
+- [ ] Unknowns list is reduced to zero or converted into tracked risks.
+- [ ] Final architecture decision (hybrid vs full GeoServer primary) is documented with measurable readiness criteria.


### PR DESCRIPTION
## What

- Propagate the `instance_class: F4 → F4_1G` bump (shipped to production in `v1.1.5` via `hotfix/v1.1.5`) into the shared `.github/app.template.yaml` on `staging`.
- Add `docs/app-engine-oom-instance-churn.md` documenting the degradation and fix.

## Why

Production ran `gunicorn -w 8` on an F4 (1 GB) instance. Eight workers each importing the full stack (sqlalchemy + geoalchemy2 + shapely + cloud-sql connector + pygeoapi) exceeded 1 GB, so App Engine terminated processes for *"using too much memory"* (~44×/3h; 304 `Booting worker`, 297 `SIGTERM` in a 3h window) and cycled workers continuously — every request re-cold-loaded the app, so the API was uniformly slow even at low traffic.

The hotfix already shipped to prod, but `staging` still read `instance_class: F4`. Without this, the next `staging → production` release would regress prod back to F4 and reintroduce the churn.

## Verification (production, post-`v1.1.5`)

- Live serving version now `F4_1G`, 100% traffic.
- `0` over-memory terminations after the new version took traffic (was ~44/3h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)