### PR TITLE
feat(ogc): filter ogc_* views to public records (BDMS-971 A1)

### DIFF
--- a/alembic/versions/f4a5b6c7d8e9_apply_public_release_status_filter_to_ogc_views.py
+++ b/alembic/versions/f4a5b6c7d8e9_apply_public_release_status_filter_to_ogc_views.py
@@ -1,0 +1,1276 @@
+"""apply public release_status filter to ogc views
+
+Restricts every ogc_* view/materialized view to release_status = 'public'
+so that published, unauthenticated OGC endpoints (/ogcapi) never expose
+private or draft records. Reversible: downgrade() recreates the same 22
+relations with the byte-identical unfiltered SQL that was in production
+before this migration, so "no predicate" is restored exactly rather than
+approximated.
+
+ogc_actively_monitored_wells gets no predicate of its own -- it inherits
+public-only rows transitively once ogc_water_well_summary is filtered (see
+alembic/versions/w1x2y3z4a5b6_drop_child_release_filters_from_ngwmn_views.py
+for why an extra child-table release_status filter here would be wrong).
+Because it depends on ogc_water_well_summary via a direct JOIN, it must be
+dropped before ogc_water_well_summary and recreated after.
+
+ogc_locations does not exist before this migration -- core/pygeoapi-config.yml
+points the locations collection directly at the raw location table. This
+migration creates ogc_locations for the first time (explicit column list,
+no SELECT *, matching every other view in this file) and a separate change
+repoints that one config line at it. Since ogc_locations never existed
+unfiltered in production, downgrade() drops it rather than recreating an
+unfiltered copy.
+
+Revision ID: f4a5b6c7d8e9
+Revises: y3z4a5b6c7d8
+Create Date: 2026-07-14 00:00:00.000000
+"""
+
+import re
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import inspect, text
+
+# revision identifiers, used by Alembic.
+revision: str = "f4a5b6c7d8e9"
+down_revision: Union[str, Sequence[str], None] = "y3z4a5b6c7d8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+REQUIRED_TABLES = {
+    "thing",
+    "location",
+    "location_thing_association",
+    "group",
+    "group_thing_association",
+    "status_history",
+    "observation",
+    "sample",
+    "field_activity",
+    "field_event",
+    "data_provenance",
+    "NMA_MajorChemistry",
+    "NMA_Chemistry_SampleInfo",
+    "NMA_MinorTraceChemistry",
+}
+
+LATEST_LOCATION_CTE = """
+SELECT DISTINCT ON (lta.thing_id)
+    lta.thing_id,
+    lta.location_id,
+    lta.effective_start
+FROM location_thing_association AS lta
+WHERE lta.effective_end IS NULL
+ORDER BY lta.thing_id, lta.effective_start DESC
+""".strip()
+
+# The 11 thing-type views still in scope after
+# s4t5u6v7w8x9_drop_unused_well_type_ogc_views.py removed the well-subtype
+# variants (abandoned_wells, artesian_wells, dry_holes, dug_wells,
+# exploration_wells, injection_wells, monitoring_wells, observation_wells,
+# piezometers, production_wells, test_wells).
+THING_VIEWS = [
+    ("water_wells", "water well"),
+    ("springs", "spring"),
+    ("diversions_surface_water", "diversion of surface water, etc."),
+    ("ephemeral_streams", "ephemeral stream"),
+    ("lakes_ponds_reservoirs", "lake, pond or reservoir"),
+    ("meteorological_stations", "meteorological station"),
+    ("other_things", "other"),
+    ("outfalls_wastewater_return_flow", "outfall of wastewater or return flow"),
+    ("perennial_streams", "perennial stream"),
+    ("rock_sample_locations", "rock sample location"),
+    ("soil_gas_sample_locations", "soil gas sample location"),
+]
+
+
+def _safe_view_id(view_id: str) -> str:
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", view_id):
+        raise ValueError(f"Unsafe view id: {view_id!r}")
+    return view_id
+
+
+def _drop_view_or_materialized_view(view_name: str) -> None:
+    # DROP VIEW IF EXISTS / DROP MATERIALIZED VIEW IF EXISTS only suppress
+    # "relation does not exist" -- Postgres still raises WrongObjectType if
+    # the relation exists as the other kind (e.g. DROP VIEW against an
+    # existing materialized view), so the relation's actual kind must be
+    # checked first rather than trying both blindly.
+    bind = op.get_bind()
+    relkind = bind.execute(
+        text("SELECT relkind FROM pg_class WHERE oid = to_regclass(:name)"),
+        {"name": view_name},
+    ).scalar()
+    if relkind == "m":
+        op.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {view_name}"))
+    elif relkind == "v":
+        op.execute(text(f"DROP VIEW IF EXISTS {view_name}"))
+
+
+def _check_required_tables() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing_tables = set(inspector.get_table_names(schema="public"))
+    missing = REQUIRED_TABLES - existing_tables
+    if missing:
+        raise RuntimeError(
+            "Cannot apply public release_status filter to OGC views. "
+            f"Missing required tables: {', '.join(sorted(missing))}"
+        )
+
+
+def _create_thing_view(view_id: str, thing_type: str, public_only: bool) -> str:
+    safe_view_id = _safe_view_id(view_id)
+    escaped_thing_type = thing_type.replace("'", "''")
+    release_filter = " AND t.release_status = 'public'" if public_only else ""
+    return f"""
+        CREATE VIEW ogc_{safe_view_id} AS
+        WITH latest_location AS (
+{LATEST_LOCATION_CTE}
+        )
+        SELECT
+            t.id,
+            t.name,
+            t.first_visit_date,
+            t.nma_pk_welldata,
+            t.well_depth,
+            t.hole_depth,
+            t.well_casing_diameter,
+            t.well_casing_depth,
+            t.well_completion_date,
+            t.well_driller_name,
+            t.well_construction_method,
+            t.well_pump_type,
+            t.well_pump_depth,
+            t.formation_completion_code,
+            t.nma_formation_zone,
+            t.release_status,
+            l.elevation,
+            l.point
+        FROM thing AS t
+        JOIN latest_location AS ll ON ll.thing_id = t.id
+        JOIN location AS l ON l.id = ll.location_id
+        WHERE t.thing_type = '{escaped_thing_type}'{release_filter}
+    """
+
+
+def _create_latest_depth_view(public_only: bool) -> str:
+    release_filter = " AND t.release_status = 'public'" if public_only else ""
+    return f"""
+        CREATE MATERIALIZED VIEW ogc_latest_depth_to_water_wells AS
+        WITH latest_location AS (
+{LATEST_LOCATION_CTE}
+        ),
+        ranked_obs AS (
+            SELECT
+                fe.thing_id,
+                o.id AS observation_id,
+                o.observation_datetime,
+                o.value,
+                o.measuring_point_height,
+                -- Treat NULL measuring_point_height as 0 when computing
+                -- depth_to_water_bgs.
+                (
+                    o.value - COALESCE(o.measuring_point_height, 0)
+                ) AS depth_to_water_bgs,
+                ROW_NUMBER() OVER (
+                    PARTITION BY fe.thing_id
+                    ORDER BY o.observation_datetime DESC, o.id DESC
+                ) AS rn
+            FROM observation AS o
+            JOIN sample AS s ON s.id = o.sample_id
+            JOIN field_activity AS fa ON fa.id = s.field_activity_id
+            JOIN field_event AS fe ON fe.id = fa.field_event_id
+            JOIN thing AS t ON t.id = fe.thing_id
+            WHERE
+                t.thing_type = 'water well'
+                AND fa.activity_type = 'groundwater level'
+                AND o.value IS NOT NULL{release_filter}
+        )
+        SELECT
+            t.id AS id,
+            t.name,
+            t.thing_type,
+            ro.observation_id,
+            ro.observation_datetime,
+            ro.value AS depth_to_water_reference,
+            ro.measuring_point_height,
+            ro.depth_to_water_bgs,
+            l.point
+        FROM ranked_obs AS ro
+        JOIN thing AS t ON t.id = ro.thing_id
+        JOIN latest_location AS ll ON ll.thing_id = t.id
+        JOIN location AS l ON l.id = ll.location_id
+        WHERE ro.rn = 1
+    """
+
+
+def _create_avg_tds_view(public_only: bool) -> str:
+    release_filter = " AND t.release_status = 'public'" if public_only else ""
+    return f"""
+        CREATE MATERIALIZED VIEW ogc_avg_tds_wells AS
+        WITH latest_location AS (
+{LATEST_LOCATION_CTE}
+        ),
+        tds_obs AS (
+            SELECT
+                csi.thing_id,
+                mc.id AS major_chemistry_id,
+                COALESCE(mc."AnalysisDate", csi."CollectionDate")::date AS observation_date,
+                mc."SampleValue" AS sample_value,
+                mc."Units" AS units
+            FROM "NMA_MajorChemistry" AS mc
+            JOIN "NMA_Chemistry_SampleInfo" AS csi
+                ON csi.id = mc.chemistry_sample_info_id
+            JOIN thing AS t ON t.id = csi.thing_id
+            WHERE
+                t.thing_type = 'water well'
+                AND mc."SampleValue" IS NOT NULL
+                AND (
+                    lower(coalesce(mc."Analyte", '')) IN (
+                        'tds',
+                        'total dissolved solids'
+                    )
+                    OR lower(coalesce(mc."Symbol", '')) = 'tds'
+                ){release_filter}
+        )
+        SELECT
+            t.id AS id,
+            t.name,
+            t.thing_type,
+            COUNT(to2.major_chemistry_id)::integer AS tds_observation_count,
+            AVG(to2.sample_value)::double precision AS avg_tds_value,
+            MIN(to2.observation_date) AS first_tds_observation_date,
+            MAX(to2.observation_date) AS last_tds_observation_date,
+            l.point
+        FROM tds_obs AS to2
+        JOIN thing AS t ON t.id = to2.thing_id
+        JOIN latest_location AS ll ON ll.thing_id = t.id
+        JOIN location AS l ON l.id = ll.location_id
+        GROUP BY t.id, t.name, t.thing_type, l.point
+    """
+
+
+def _create_latest_tds_view(public_only: bool) -> str:
+    release_filter = " AND t.release_status = 'public'" if public_only else ""
+    return f"""
+        CREATE VIEW ogc_latest_tds_wells AS
+        WITH latest_location AS (
+{LATEST_LOCATION_CTE}
+        ),
+        tds_obs AS (
+            SELECT
+                csi.thing_id,
+                mc.id AS major_chemistry_id,
+                COALESCE(mc."AnalysisDate", csi."CollectionDate") AS observation_datetime,
+                mc."SampleValue" AS sample_value,
+                mc."Units" AS units
+            FROM "NMA_MajorChemistry" AS mc
+            JOIN "NMA_Chemistry_SampleInfo" AS csi
+                ON csi.id = mc.chemistry_sample_info_id
+            JOIN thing AS t ON t.id = csi.thing_id
+            WHERE
+                t.thing_type = 'water well'
+                AND mc."SampleValue" IS NOT NULL
+                AND (
+                    lower(coalesce(mc."Analyte", '')) IN (
+                        'tds',
+                        'total dissolved solids'
+                    )
+                    OR lower(coalesce(mc."Symbol", '')) = 'tds'
+                ){release_filter}
+        ),
+        ranked_tds AS (
+            SELECT
+                to2.thing_id,
+                to2.major_chemistry_id,
+                to2.observation_datetime,
+                to2.sample_value,
+                to2.units,
+                ROW_NUMBER() OVER (
+                    PARTITION BY to2.thing_id
+                    ORDER BY to2.observation_datetime DESC NULLS LAST, to2.major_chemistry_id DESC
+                ) AS rn
+            FROM tds_obs AS to2
+        )
+        SELECT
+            t.id AS id,
+            t.name,
+            t.thing_type,
+            rt.major_chemistry_id,
+            rt.observation_datetime::date AS latest_tds_observation_date,
+            rt.sample_value AS latest_tds_value,
+            rt.units AS latest_tds_units,
+            l.point
+        FROM ranked_tds AS rt
+        JOIN thing AS t ON t.id = rt.thing_id
+        JOIN latest_location AS ll ON ll.thing_id = t.id
+        JOIN location AS l ON l.id = ll.location_id
+        WHERE rt.rn = 1
+    """
+
+
+def _create_depth_to_water_trend_view(public_only: bool) -> str:
+    release_filter = " AND t.release_status = 'public'" if public_only else ""
+    return f"""
+        CREATE MATERIALIZED VIEW ogc_depth_to_water_trend_wells AS
+        WITH latest_location AS (
+{LATEST_LOCATION_CTE}
+        ),
+        obs AS (
+            SELECT
+                fe.thing_id,
+                o.observation_datetime,
+                (o.value - COALESCE(o.measuring_point_height, 0)) AS depth_to_water_bgs
+            FROM observation AS o
+            JOIN sample AS s ON s.id = o.sample_id
+            JOIN field_activity AS fa ON fa.id = s.field_activity_id
+            JOIN field_event AS fe ON fe.id = fa.field_event_id
+            JOIN thing AS t ON t.id = fe.thing_id
+            WHERE
+                t.thing_type = 'water well'
+                AND fa.activity_type = 'groundwater level'
+                AND o.value IS NOT NULL
+                AND o.observation_datetime IS NOT NULL{release_filter}
+        ),
+        agg AS (
+            SELECT
+                ob.thing_id,
+                COUNT(*)::integer AS record_count,
+                MIN(ob.observation_datetime) AS first_observation_datetime,
+                MAX(ob.observation_datetime) AS last_observation_datetime,
+                EXTRACT(EPOCH FROM (MAX(ob.observation_datetime) - MIN(ob.observation_datetime)))
+                    / 31557600.0 AS span_years,
+                REGR_SLOPE(
+                    ob.depth_to_water_bgs,
+                    EXTRACT(EPOCH FROM ob.observation_datetime)
+                ) * 31557600.0 AS slope_ft_per_year
+            FROM obs AS ob
+            GROUP BY ob.thing_id
+        )
+        SELECT
+            t.id AS id,
+            t.name,
+            t.thing_type,
+            a.record_count,
+            a.first_observation_datetime,
+            a.last_observation_datetime,
+            a.span_years,
+            a.slope_ft_per_year,
+            CASE
+                WHEN a.record_count >= 10 OR (a.record_count >= 4 AND a.span_years >= 2.0) THEN
+                    CASE
+                        WHEN a.slope_ft_per_year IS NULL THEN 'not enough data'
+                        WHEN a.slope_ft_per_year > 0.25 THEN 'increasing'
+                        WHEN a.slope_ft_per_year < -0.25 THEN 'decreasing'
+                        ELSE 'stable'
+                    END
+                ELSE 'not enough data'
+            END AS trend_category,
+            l.point
+        FROM agg AS a
+        JOIN thing AS t ON t.id = a.thing_id
+        JOIN latest_location AS ll ON ll.thing_id = t.id
+        JOIN location AS l ON l.id = ll.location_id
+    """
+
+
+def _create_water_well_summary_view(public_only: bool) -> str:
+    release_filter = " AND t.release_status = 'public'" if public_only else ""
+    return f"""
+        CREATE MATERIALIZED VIEW ogc_water_well_summary AS
+        WITH latest_location AS (
+{LATEST_LOCATION_CTE}
+        ),
+        wl_obs AS (
+            SELECT
+                fe.thing_id,
+                o.id AS observation_id,
+                o.observation_datetime,
+                (o.value - COALESCE(o.measuring_point_height, 0)) AS water_level
+            FROM observation AS o
+            JOIN sample AS s ON s.id = o.sample_id
+            JOIN field_activity AS fa ON fa.id = s.field_activity_id
+            JOIN field_event AS fe ON fe.id = fa.field_event_id
+            JOIN thing AS t ON t.id = fe.thing_id
+            WHERE
+                t.thing_type = 'water well'
+                AND fa.activity_type = 'groundwater level'
+                AND o.value IS NOT NULL
+                AND o.observation_datetime IS NOT NULL{release_filter}
+        ),
+        wl_agg AS (
+            SELECT
+                w.thing_id,
+                COUNT(*)::integer AS total_water_levels,
+                MIN(w.water_level) AS min_water_level,
+                MAX(w.water_level) AS max_water_level,
+                REGR_SLOPE(
+                    w.water_level,
+                    EXTRACT(EPOCH FROM w.observation_datetime)
+                ) * 31557600.0 AS water_level_trend_ft_per_year
+            FROM wl_obs AS w
+            GROUP BY w.thing_id
+        ),
+        wl_last AS (
+            SELECT
+                ranked.thing_id,
+                ranked.water_level AS last_water_level,
+                ranked.observation_datetime AS last_water_level_datetime
+            FROM (
+                SELECT
+                    w.thing_id,
+                    w.water_level,
+                    w.observation_datetime,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY w.thing_id
+                        ORDER BY w.observation_datetime DESC, w.observation_id DESC
+                    ) AS rn
+                FROM wl_obs AS w
+            ) AS ranked
+            WHERE ranked.rn = 1
+        )
+        SELECT
+            t.id AS id,
+            t.name,
+            t.well_depth,
+            l.elevation,
+            dpl.collection_method AS elevation_method,
+            t.nma_formation_zone AS formation_zone,
+            wa.total_water_levels,
+            wl.last_water_level,
+            wl.last_water_level_datetime,
+            wa.min_water_level,
+            wa.max_water_level,
+            wa.water_level_trend_ft_per_year,
+            l.point
+        FROM thing AS t
+        JOIN latest_location AS ll ON ll.thing_id = t.id
+        JOIN location AS l ON l.id = ll.location_id
+        JOIN wl_agg AS wa ON wa.thing_id = t.id
+        LEFT JOIN wl_last AS wl ON wl.thing_id = t.id
+        LEFT JOIN LATERAL (
+            SELECT dp.collection_method
+            FROM data_provenance AS dp
+            WHERE
+                dp.target_table = 'location'
+                AND dp.target_id = l.id
+                AND dp.field_name = 'elevation'
+            ORDER BY dp.id DESC
+            LIMIT 1
+        ) AS dpl ON true
+        WHERE t.thing_type = 'water well'
+          AND wa.total_water_levels > 0
+    """
+
+
+# Static analyte columns for major chemistry pivots.
+# Includes aliases observed in current DB values (e.g., Ca(total), IONBAL, TAn, TCat, Na+K).
+STATIC_ANALYTE_COLUMNS_MAJOR: list[tuple[str, str]] = [
+    ("tds", "tds"),
+    ("calcium", "calcium"),
+    ("calcium_total", "calcium_total"),
+    ("magnesium", "magnesium"),
+    ("magnesium_total", "magnesium_total"),
+    ("sodium", "sodium"),
+    ("sodium_total", "sodium_total"),
+    ("potassium", "potassium"),
+    ("potassium_total", "potassium_total"),
+    ("sodium_plus_potassium", "sodium_plus_potassium"),
+    ("bicarbonate", "bicarbonate"),
+    ("carbonate", "carbonate"),
+    ("sulfate", "sulfate"),
+    ("chloride", "chloride"),
+    ("ion_balance", "ion_balance"),
+    ("total_anions", "total_anions"),
+    ("total_cations", "total_cations"),
+    ("alkalinity", "alkalinity"),
+    ("hardness", "hardness"),
+    ("specific_conductance", "specific_conductance"),
+    ("ph", "ph"),
+    ("nitrate", "nitrate"),
+    ("fluoride", "fluoride"),
+    ("silica", "silica"),
+]
+
+
+def _major_chemistry_select_columns() -> str:
+    return ",\n".join(
+        [
+            (
+                "            MAX(lr.sample_value) FILTER "
+                f"(WHERE lr.analyte_key = '{analyte_key}') AS {column_name}"
+            )
+            for analyte_key, column_name in STATIC_ANALYTE_COLUMNS_MAJOR
+        ]
+    )
+
+
+def _major_chemistry_unit_columns() -> str:
+    return ",\n".join(
+        [
+            (
+                "            MAX(lr.units) FILTER "
+                f"(WHERE lr.analyte_key = '{analyte_key}') AS {column_name}_units"
+            )
+            for analyte_key, column_name in STATIC_ANALYTE_COLUMNS_MAJOR
+        ]
+    )
+
+
+def _create_major_chemistry_results_view(public_only: bool) -> str:
+    static_columns = _major_chemistry_select_columns()
+    static_unit_columns = _major_chemistry_unit_columns()
+    release_filter = " AND t.release_status = 'public'" if public_only else ""
+    return f"""
+        CREATE MATERIALIZED VIEW ogc_major_chemistry_results AS
+        WITH latest_location AS (
+{LATEST_LOCATION_CTE}
+        ),
+        chemistry_rows AS (
+            SELECT
+                csi.thing_id,
+                mc.id AS result_id,
+                COALESCE(mc."AnalysisDate", csi."CollectionDate") AS observation_datetime,
+                trim(mc."Analyte") AS analyte_name,
+                trim(mc."Symbol") AS symbol_name,
+                mc."SampleValue"::double precision AS sample_value,
+                mc."Units" AS units
+            FROM "NMA_MajorChemistry" AS mc
+            JOIN "NMA_Chemistry_SampleInfo" AS csi
+                ON csi.id = mc.chemistry_sample_info_id
+            JOIN thing AS t
+                ON t.id = csi.thing_id
+            WHERE mc."SampleValue" IS NOT NULL
+              AND t.thing_type = 'water well'{release_filter}
+        ),
+        normalized_rows AS (
+            SELECT
+                cr.thing_id,
+                cr.result_id,
+                cr.observation_datetime,
+                NULLIF(
+                    regexp_replace(
+                        lower(trim(coalesce(cr.analyte_name, ''))),
+                        '[^a-z0-9]+',
+                        '',
+                        'g'
+                    ),
+                    ''
+                ) AS analyte_token,
+                NULLIF(
+                    regexp_replace(
+                        lower(trim(coalesce(cr.symbol_name, ''))),
+                        '[^a-z0-9]+',
+                        '',
+                        'g'
+                    ),
+                    ''
+                ) AS symbol_token,
+                cr.sample_value,
+                cr.units
+            FROM chemistry_rows AS cr
+        ),
+        mapped_rows AS (
+            SELECT
+                nr.thing_id,
+                nr.result_id,
+                nr.observation_datetime,
+                CASE
+                    WHEN coalesce(nr.symbol_token, '') = 'tds'
+                        OR coalesce(nr.analyte_token, '') IN ('tds', 'totaldissolvedsolids')
+                        THEN 'tds'
+
+                    WHEN coalesce(nr.symbol_token, '') = 'ca'
+                        OR coalesce(nr.analyte_token, '') = 'ca'
+                        THEN 'calcium'
+                    WHEN coalesce(nr.analyte_token, '') = 'catotal'
+                        THEN 'calcium_total'
+
+                    WHEN coalesce(nr.symbol_token, '') = 'mg'
+                        OR coalesce(nr.analyte_token, '') = 'mg'
+                        THEN 'magnesium'
+                    WHEN coalesce(nr.analyte_token, '') = 'mgtotal'
+                        THEN 'magnesium_total'
+
+                    WHEN coalesce(nr.symbol_token, '') = 'na'
+                        OR coalesce(nr.analyte_token, '') = 'na'
+                        THEN 'sodium'
+                    WHEN coalesce(nr.analyte_token, '') = 'natotal'
+                        THEN 'sodium_total'
+
+                    WHEN coalesce(nr.symbol_token, '') = 'k'
+                        OR coalesce(nr.analyte_token, '') = 'k'
+                        THEN 'potassium'
+                    WHEN coalesce(nr.analyte_token, '') = 'ktotal'
+                        THEN 'potassium_total'
+
+                    WHEN coalesce(nr.analyte_token, '') = 'nak'
+                        THEN 'sodium_plus_potassium'
+
+                    WHEN coalesce(nr.symbol_token, '') = 'hco3'
+                        OR coalesce(nr.analyte_token, '') = 'hco3'
+                        THEN 'bicarbonate'
+                    WHEN coalesce(nr.symbol_token, '') = 'co3'
+                        OR coalesce(nr.analyte_token, '') = 'co3'
+                        THEN 'carbonate'
+                    WHEN coalesce(nr.symbol_token, '') = 'so4'
+                        OR coalesce(nr.analyte_token, '') = 'so4'
+                        THEN 'sulfate'
+                    WHEN coalesce(nr.symbol_token, '') = 'cl'
+                        OR coalesce(nr.analyte_token, '') = 'cl'
+                        THEN 'chloride'
+
+                    WHEN coalesce(nr.analyte_token, '') = 'ionbal'
+                        THEN 'ion_balance'
+                    WHEN coalesce(nr.analyte_token, '') = 'tan'
+                        THEN 'total_anions'
+                    WHEN coalesce(nr.analyte_token, '') = 'tcat'
+                        THEN 'total_cations'
+
+                    WHEN coalesce(nr.analyte_token, '') IN ('alk', 'alkalinity')
+                        THEN 'alkalinity'
+                    WHEN coalesce(nr.analyte_token, '') IN ('hrd', 'hardness')
+                        THEN 'hardness'
+                    WHEN coalesce(nr.analyte_token, '') IN (
+                        'condlab',
+                        'specificconductance',
+                        'specificconductivity',
+                        'conductivity'
+                    )
+                        THEN 'specific_conductance'
+                    WHEN coalesce(nr.symbol_token, '') = 'ph'
+                        OR coalesce(nr.analyte_token, '') IN ('ph', 'phl')
+                        THEN 'ph'
+
+                    WHEN coalesce(nr.symbol_token, '') = 'no3'
+                        OR coalesce(nr.analyte_token, '') IN ('no3', 'nitrate')
+                        THEN 'nitrate'
+                    WHEN coalesce(nr.symbol_token, '') = 'f'
+                        OR coalesce(nr.analyte_token, '') IN ('f', 'fluoride')
+                        THEN 'fluoride'
+                    WHEN coalesce(nr.symbol_token, '') = 'sio2'
+                        OR coalesce(nr.analyte_token, '') IN ('sio2', 'silica')
+                        THEN 'silica'
+
+                    ELSE NULL
+                END AS analyte_key,
+                nr.sample_value,
+                nr.units
+            FROM normalized_rows AS nr
+        ),
+        latest_results AS (
+            SELECT
+                mr.thing_id,
+                mr.analyte_key,
+                mr.sample_value,
+                mr.units,
+                mr.observation_datetime,
+                ROW_NUMBER() OVER (
+                    PARTITION BY mr.thing_id, mr.analyte_key
+                    ORDER BY mr.observation_datetime DESC NULLS LAST, mr.result_id DESC
+                ) AS rn
+            FROM mapped_rows AS mr
+            WHERE mr.analyte_key IS NOT NULL
+        )
+        SELECT
+            t.id AS id,
+            ll.location_id,
+            t.name,
+            t.thing_type,
+            COUNT(*)::integer AS analyte_count,
+            MAX(lr.observation_datetime::date) AS latest_chemistry_date,
+{static_columns},
+{static_unit_columns},
+            l.point
+        FROM latest_results AS lr
+        JOIN thing AS t ON t.id = lr.thing_id
+        JOIN latest_location AS ll ON ll.thing_id = t.id
+        JOIN location AS l ON l.id = ll.location_id
+        WHERE lr.rn = 1
+        GROUP BY t.id, ll.location_id, t.name, t.thing_type, l.point
+    """
+
+
+STATIC_ANALYTE_COLUMNS_MINOR: list[tuple[str, str]] = [
+    ("h2r", "h2r"),
+    ("o18r", "o18r"),
+    ("c13r", "c13r"),
+    ("c14", "c14"),
+    ("c14_years", "c14_years"),
+    ("fluoride", "fluoride"),
+    ("barium", "barium"),
+    ("barium_total", "barium_total"),
+    ("copper", "copper"),
+    ("copper_total", "copper_total"),
+    ("zinc", "zinc"),
+    ("zinc_total", "zinc_total"),
+    ("molybdenum", "molybdenum"),
+    ("molybdenum_total", "molybdenum_total"),
+    ("silica", "silica"),
+    ("silicon", "silicon"),
+    ("silicon_total", "silicon_total"),
+    ("manganese", "manganese"),
+    ("manganese_total", "manganese_total"),
+    ("iron", "iron"),
+    ("iron_total", "iron_total"),
+    ("strontium", "strontium"),
+    ("strontium_total", "strontium_total"),
+    ("chromium", "chromium"),
+    ("chromium_total", "chromium_total"),
+    ("boron", "boron"),
+    ("boron_total", "boron_total"),
+    ("uranium", "uranium"),
+    ("uranium_total", "uranium_total"),
+    ("lithium", "lithium"),
+    ("lithium_total", "lithium_total"),
+    ("silver", "silver"),
+    ("silver_total", "silver_total"),
+    ("antimony", "antimony"),
+    ("antimony_total", "antimony_total"),
+    ("beryllium", "beryllium"),
+    ("beryllium_total", "beryllium_total"),
+    ("lead", "lead"),
+    ("lead_total", "lead_total"),
+    ("thallium", "thallium"),
+    ("thallium_total", "thallium_total"),
+    ("bromide", "bromide"),
+    ("selenium", "selenium"),
+    ("selenium_total", "selenium_total"),
+    ("vanadium", "vanadium"),
+    ("vanadium_total", "vanadium_total"),
+    ("aluminum", "aluminum"),
+    ("aluminum_total", "aluminum_total"),
+    ("arsenic", "arsenic"),
+    ("arsenic_total", "arsenic_total"),
+    ("nickel", "nickel"),
+    ("nickel_total", "nickel_total"),
+    ("cadmium", "cadmium"),
+    ("cadmium_total", "cadmium_total"),
+    ("cobalt", "cobalt"),
+    ("cobalt_total", "cobalt_total"),
+    ("phosphate", "phosphate"),
+    ("nitrite", "nitrite"),
+    ("nitrate", "nitrate"),
+    ("nitrate_as_n", "nitrate_as_n"),
+    ("thorium", "thorium"),
+    ("thorium_total", "thorium_total"),
+    ("tin", "tin"),
+    ("tin_total", "tin_total"),
+    ("mercury", "mercury"),
+    ("mercury_total", "mercury_total"),
+    ("titanium", "titanium"),
+    ("titanium_total", "titanium_total"),
+]
+
+
+def _minor_chemistry_value_columns() -> str:
+    return ",\n".join(
+        [
+            (
+                "            MAX(lr.sample_value) FILTER "
+                f"(WHERE lr.analyte_key = '{analyte_key}') AS {column_name}"
+            )
+            for analyte_key, column_name in STATIC_ANALYTE_COLUMNS_MINOR
+        ]
+    )
+
+
+def _minor_chemistry_unit_columns() -> str:
+    return ",\n".join(
+        [
+            (
+                "            MAX(lr.units) FILTER "
+                f"(WHERE lr.analyte_key = '{analyte_key}') AS {column_name}_units"
+            )
+            for analyte_key, column_name in STATIC_ANALYTE_COLUMNS_MINOR
+        ]
+    )
+
+
+def _create_minor_chemistry_wells_view(public_only: bool) -> str:
+    value_columns = _minor_chemistry_value_columns()
+    unit_columns = _minor_chemistry_unit_columns()
+    release_filter = " AND t.release_status = 'public'" if public_only else ""
+    return f"""
+        CREATE MATERIALIZED VIEW ogc_minor_chemistry_wells AS
+        WITH latest_location AS (
+{LATEST_LOCATION_CTE}
+        ),
+        chemistry_rows AS (
+            SELECT
+                csi.thing_id,
+                mtc.id AS result_id,
+                COALESCE(mtc.analysis_date::timestamp, csi."CollectionDate") AS observation_datetime,
+                trim(mtc.analyte) AS analyte_name,
+                mtc.sample_value::double precision AS sample_value,
+                mtc.units AS units
+            FROM "NMA_MinorTraceChemistry" AS mtc
+            JOIN "NMA_Chemistry_SampleInfo" AS csi
+                ON csi.id = mtc.chemistry_sample_info_id
+            JOIN thing AS t ON t.id = csi.thing_id
+            WHERE
+                mtc.sample_value IS NOT NULL
+                AND t.thing_type = 'water well'{release_filter}
+        ),
+        normalized_rows AS (
+            SELECT
+                cr.thing_id,
+                cr.result_id,
+                cr.observation_datetime,
+                NULLIF(
+                    regexp_replace(
+                        lower(trim(coalesce(cr.analyte_name, ''))),
+                        '[^a-z0-9]+',
+                        '',
+                        'g'
+                    ),
+                    ''
+                ) AS analyte_token,
+                cr.sample_value,
+                cr.units
+            FROM chemistry_rows AS cr
+        ),
+        mapped_rows AS (
+            SELECT
+                nr.thing_id,
+                nr.result_id,
+                nr.observation_datetime,
+                CASE
+                    WHEN coalesce(nr.analyte_token, '') = 'h2r' THEN 'h2r'
+                    WHEN coalesce(nr.analyte_token, '') = 'o18r' THEN 'o18r'
+                    WHEN coalesce(nr.analyte_token, '') = 'c13r' THEN 'c13r'
+                    WHEN coalesce(nr.analyte_token, '') = 'c14' THEN 'c14'
+                    WHEN coalesce(nr.analyte_token, '') = 'c14years' THEN 'c14_years'
+
+                    WHEN coalesce(nr.analyte_token, '') = 'f' THEN 'fluoride'
+                    WHEN coalesce(nr.analyte_token, '') = 'ba' THEN 'barium'
+                    WHEN coalesce(nr.analyte_token, '') = 'batotal' THEN 'barium_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'cu' THEN 'copper'
+                    WHEN coalesce(nr.analyte_token, '') = 'cutotal' THEN 'copper_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'zn' THEN 'zinc'
+                    WHEN coalesce(nr.analyte_token, '') = 'zntotal' THEN 'zinc_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'mo' THEN 'molybdenum'
+                    WHEN coalesce(nr.analyte_token, '') = 'mototal' THEN 'molybdenum_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'sio2' THEN 'silica'
+                    WHEN coalesce(nr.analyte_token, '') = 'si' THEN 'silicon'
+                    WHEN coalesce(nr.analyte_token, '') = 'sitotal' THEN 'silicon_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'mn' THEN 'manganese'
+                    WHEN coalesce(nr.analyte_token, '') = 'mntotal' THEN 'manganese_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'fe' THEN 'iron'
+                    WHEN coalesce(nr.analyte_token, '') = 'fetotal' THEN 'iron_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'sr' THEN 'strontium'
+                    WHEN coalesce(nr.analyte_token, '') = 'srtotal' THEN 'strontium_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'cr' THEN 'chromium'
+                    WHEN coalesce(nr.analyte_token, '') = 'crtotal' THEN 'chromium_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'b' THEN 'boron'
+                    WHEN coalesce(nr.analyte_token, '') = 'btotal' THEN 'boron_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'u' THEN 'uranium'
+                    WHEN coalesce(nr.analyte_token, '') = 'utotal' THEN 'uranium_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'li' THEN 'lithium'
+                    WHEN coalesce(nr.analyte_token, '') = 'litotal' THEN 'lithium_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'ag' THEN 'silver'
+                    WHEN coalesce(nr.analyte_token, '') = 'agtotal' THEN 'silver_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'sb' THEN 'antimony'
+                    WHEN coalesce(nr.analyte_token, '') = 'sbtotal' THEN 'antimony_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'be' THEN 'beryllium'
+                    WHEN coalesce(nr.analyte_token, '') = 'betotal' THEN 'beryllium_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'pb' THEN 'lead'
+                    WHEN coalesce(nr.analyte_token, '') = 'pbtotal' THEN 'lead_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'tl' THEN 'thallium'
+                    WHEN coalesce(nr.analyte_token, '') = 'tltotal' THEN 'thallium_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'br' THEN 'bromide'
+                    WHEN coalesce(nr.analyte_token, '') = 'se' THEN 'selenium'
+                    WHEN coalesce(nr.analyte_token, '') = 'setotal' THEN 'selenium_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'v' THEN 'vanadium'
+                    WHEN coalesce(nr.analyte_token, '') = 'vtotal' THEN 'vanadium_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'al' THEN 'aluminum'
+                    WHEN coalesce(nr.analyte_token, '') = 'altotal' THEN 'aluminum_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'as' THEN 'arsenic'
+                    WHEN coalesce(nr.analyte_token, '') = 'astotal' THEN 'arsenic_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'ni' THEN 'nickel'
+                    WHEN coalesce(nr.analyte_token, '') = 'nitotal' THEN 'nickel_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'cd' THEN 'cadmium'
+                    WHEN coalesce(nr.analyte_token, '') = 'cdtotal' THEN 'cadmium_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'co' THEN 'cobalt'
+                    WHEN coalesce(nr.analyte_token, '') = 'cototal' THEN 'cobalt_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'po4' THEN 'phosphate'
+                    WHEN coalesce(nr.analyte_token, '') = 'no2' THEN 'nitrite'
+                    WHEN coalesce(nr.analyte_token, '') = 'no3' THEN 'nitrate'
+                    WHEN coalesce(nr.analyte_token, '') = 'no3n' THEN 'nitrate_as_n'
+                    WHEN coalesce(nr.analyte_token, '') = 'th' THEN 'thorium'
+                    WHEN coalesce(nr.analyte_token, '') = 'thtotal' THEN 'thorium_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'sn' THEN 'tin'
+                    WHEN coalesce(nr.analyte_token, '') = 'sntotal' THEN 'tin_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'hg' THEN 'mercury'
+                    WHEN coalesce(nr.analyte_token, '') = 'hgtotal' THEN 'mercury_total'
+                    WHEN coalesce(nr.analyte_token, '') = 'ti' THEN 'titanium'
+                    WHEN coalesce(nr.analyte_token, '') = 'titotal' THEN 'titanium_total'
+                    ELSE NULL
+                END AS analyte_key,
+                nr.sample_value,
+                nr.units
+            FROM normalized_rows AS nr
+        ),
+        latest_results AS (
+            SELECT
+                mr.thing_id,
+                mr.analyte_key,
+                mr.sample_value,
+                mr.units,
+                mr.observation_datetime,
+                ROW_NUMBER() OVER (
+                    PARTITION BY mr.thing_id, mr.analyte_key
+                    ORDER BY mr.observation_datetime DESC NULLS LAST, mr.result_id DESC
+                ) AS rn
+            FROM mapped_rows AS mr
+            WHERE mr.analyte_key IS NOT NULL
+        )
+        SELECT
+            t.id AS id,
+            ll.location_id,
+            t.name,
+            t.thing_type,
+            COUNT(*)::integer AS analyte_count,
+            MAX(lr.observation_datetime::date) AS latest_chemistry_date,
+{value_columns},
+{unit_columns},
+            l.point
+        FROM latest_results AS lr
+        JOIN thing AS t ON t.id = lr.thing_id
+        JOIN latest_location AS ll ON ll.thing_id = t.id
+        JOIN location AS l ON l.id = ll.location_id
+        WHERE lr.rn = 1
+          AND t.thing_type = 'water well'
+        GROUP BY t.id, ll.location_id, t.name, t.thing_type, l.point
+    """
+
+
+METERS_TO_FEET = 3.28084
+
+
+def _create_water_elevation_view(public_only: bool) -> str:
+    release_filter = " AND t.release_status = 'public'" if public_only else ""
+    return f"""
+        CREATE MATERIALIZED VIEW ogc_water_elevation_wells AS
+        WITH latest_location AS (
+{LATEST_LOCATION_CTE}
+        ),
+        ranked_obs AS (
+            SELECT
+                fe.thing_id,
+                o.id AS observation_id,
+                o.observation_datetime,
+                CASE
+                    WHEN lower(trim(o.unit)) IN ('m', 'meter', 'meters', 'metre', 'metres') THEN
+                        (o.value * {METERS_TO_FEET}) - COALESCE(o.measuring_point_height, 0)
+                    WHEN lower(trim(o.unit)) IN ('ft', 'foot', 'feet') THEN
+                        o.value - COALESCE(o.measuring_point_height, 0)
+                    ELSE
+                        NULL
+                END AS depth_to_water_below_ground_surface
+            FROM observation AS o
+            JOIN sample AS s ON s.id = o.sample_id
+            JOIN field_activity AS fa ON fa.id = s.field_activity_id
+            JOIN field_event AS fe ON fe.id = fa.field_event_id
+            JOIN thing AS t ON t.id = fe.thing_id
+            WHERE
+                t.thing_type = 'water well'
+                AND fa.activity_type = 'groundwater level'
+                AND o.value IS NOT NULL
+                AND o.observation_datetime IS NOT NULL
+                AND lower(trim(o.unit)) IN (
+                    'm',
+                    'meter',
+                    'meters',
+                    'metre',
+                    'metres',
+                    'ft',
+                    'foot',
+                    'feet'
+                ){release_filter}
+        ),
+        latest_obs AS (
+            SELECT
+                ro.*,
+                ROW_NUMBER() OVER (
+                    PARTITION BY ro.thing_id
+                    ORDER BY ro.observation_datetime DESC, ro.observation_id DESC
+                ) AS rn
+            FROM ranked_obs AS ro
+        )
+        SELECT
+            t.id AS id,
+            t.name,
+            t.thing_type,
+            lo.observation_id,
+            lo.observation_datetime,
+            l.elevation AS elevation_m,
+            lo.depth_to_water_below_ground_surface AS depth_to_water_below_ground_surface_ft,
+            ((l.elevation * {METERS_TO_FEET}) - lo.depth_to_water_below_ground_surface)
+                AS water_elevation_ft,
+            l.point
+        FROM latest_obs AS lo
+        JOIN thing AS t ON t.id = lo.thing_id
+        JOIN latest_location AS ll ON ll.thing_id = t.id
+        JOIN location AS l ON l.id = ll.location_id
+        WHERE lo.rn = 1
+    """
+
+
+def _create_actively_monitored_wells_view() -> str:
+    # No predicate of its own -- inherits public-only rows transitively via
+    # the JOIN to ogc_water_well_summary, which is itself filtered. Adding a
+    # filter on status_history.release_status here would repeat the mistake
+    # reverted in w1x2y3z4a5b6 (that column is never actually populated for
+    # this table).
+    return """
+        CREATE VIEW ogc_actively_monitored_wells AS
+        WITH latest_monitoring_status AS (
+            SELECT DISTINCT ON (sh.target_id)
+                sh.target_id AS thing_id,
+                sh.status_value
+            FROM status_history AS sh
+            WHERE
+                sh.target_table = 'thing'
+                AND sh.status_type = 'Monitoring Status'
+            ORDER BY sh.target_id, sh.start_date DESC, sh.id DESC
+        )
+        SELECT
+            wws.id,
+            wws.name,
+            'water well'::text AS thing_type,
+            wws.well_depth,
+            wws.elevation,
+            wws.elevation_method,
+            wws.formation_zone,
+            wws.total_water_levels,
+            wws.last_water_level,
+            wws.last_water_level_datetime,
+            wws.min_water_level,
+            wws.max_water_level,
+            wws.water_level_trend_ft_per_year,
+            g.id AS group_id,
+            g.name AS group_name,
+            g.group_type,
+            wws.point
+        FROM "group" AS g
+        JOIN group_thing_association AS gta ON gta.group_id = g.id
+        JOIN ogc_water_well_summary AS wws ON wws.id = gta.thing_id
+        JOIN latest_monitoring_status AS lms ON lms.thing_id = wws.id
+        WHERE lower(trim(g.name)) = 'water level network'
+          AND lms.status_value = 'Currently monitored'
+    """
+
+
+def _create_project_areas_view(public_only: bool) -> str:
+    release_filter = " AND g.release_status = 'public'" if public_only else ""
+    return f"""
+        CREATE VIEW ogc_project_areas AS
+        SELECT
+            g.id,
+            g.name,
+            g.description,
+            g.group_type,
+            g.release_status,
+            g.project_area
+        FROM "group" AS g
+        WHERE g.project_area IS NOT NULL{release_filter}
+    """
+
+
+def _create_locations_view() -> str:
+    # Explicit column list verified against db/location.py and its mixins
+    # (AutoBaseMixin/AuditMixin, ReleaseMixin, NotesMixin, DataProvenanceMixin).
+    # NotesMixin/DataProvenanceMixin add only polymorphic relationships, no
+    # real columns. Audit columns (created_at, created_by_*, updated_by_*)
+    # are deliberately excluded, matching every other view in this file --
+    # none of them expose those columns either, even for Thing's otherwise
+    # thorough column list.
+    return """
+        CREATE VIEW ogc_locations AS
+        SELECT
+            l.id,
+            l.nma_pk_location,
+            l.description,
+            l.county,
+            l.state,
+            l.quad_name,
+            l.nma_location_notes,
+            l.nma_coordinate_notes,
+            l.nma_data_reliability,
+            l.nma_date_created,
+            l.nma_site_date,
+            l.release_status,
+            l.elevation,
+            l.point
+        FROM location AS l
+        WHERE l.release_status = 'public'
+    """
+
+
+def _recreate_governed_views(public_only: bool) -> None:
+    # ogc_actively_monitored_wells depends on ogc_water_well_summary via a
+    # direct JOIN; Postgres refuses to drop a materialized view while a
+    # dependent view exists, so it must go first and come back last.
+    _drop_view_or_materialized_view("ogc_actively_monitored_wells")
+
+    for view_id, thing_type in THING_VIEWS:
+        _drop_view_or_materialized_view(f"ogc_{_safe_view_id(view_id)}")
+        op.execute(text(_create_thing_view(view_id, thing_type, public_only)))
+
+    _drop_view_or_materialized_view("ogc_latest_depth_to_water_wells")
+    op.execute(text(_create_latest_depth_view(public_only)))
+    op.execute(
+        text(
+            "COMMENT ON MATERIALIZED VIEW ogc_latest_depth_to_water_wells IS "
+            "'Latest depth-to-water per well view for pygeoapi.'"
+        )
+    )
+    op.execute(
+        text(
+            "CREATE UNIQUE INDEX ux_ogc_latest_depth_to_water_wells_id "
+            "ON ogc_latest_depth_to_water_wells (id)"
+        )
+    )
+
+    _drop_view_or_materialized_view("ogc_avg_tds_wells")
+    op.execute(text(_create_avg_tds_view(public_only)))
+    op.execute(
+        text(
+            "COMMENT ON MATERIALIZED VIEW ogc_avg_tds_wells IS "
+            "'Average TDS per well from major chemistry results for pygeoapi.'"
+        )
+    )
+    op.execute(
+        text("CREATE UNIQUE INDEX ux_ogc_avg_tds_wells_id " "ON ogc_avg_tds_wells (id)")
+    )
+
+    _drop_view_or_materialized_view("ogc_latest_tds_wells")
+    op.execute(text(_create_latest_tds_view(public_only)))
+    op.execute(
+        text(
+            "COMMENT ON VIEW ogc_latest_tds_wells IS "
+            "'Latest TDS per well from major chemistry results for pygeoapi.'"
+        )
+    )
+
+    _drop_view_or_materialized_view("ogc_depth_to_water_trend_wells")
+    op.execute(text(_create_depth_to_water_trend_view(public_only)))
+    op.execute(
+        text(
+            "COMMENT ON MATERIALIZED VIEW ogc_depth_to_water_trend_wells IS "
+            "'Depth-to-water trend classification for water wells.'"
+        )
+    )
+    op.execute(
+        text(
+            "CREATE UNIQUE INDEX ux_ogc_depth_to_water_trend_wells_id "
+            "ON ogc_depth_to_water_trend_wells (id)"
+        )
+    )
+
+    _drop_view_or_materialized_view("ogc_water_well_summary")
+    op.execute(text(_create_water_well_summary_view(public_only)))
+    op.execute(
+        text(
+            "COMMENT ON MATERIALIZED VIEW ogc_water_well_summary IS "
+            "'Summary statistics for water wells including water-level trend.'"
+        )
+    )
+    op.execute(
+        text(
+            "CREATE UNIQUE INDEX ux_ogc_water_well_summary_id "
+            "ON ogc_water_well_summary (id)"
+        )
+    )
+
+    _drop_view_or_materialized_view("ogc_major_chemistry_results")
+    op.execute(text(_create_major_chemistry_results_view(public_only)))
+    op.execute(
+        text(
+            "COMMENT ON MATERIALIZED VIEW ogc_major_chemistry_results IS "
+            "'Latest major-chemistry analyte values per location, pivoted into static analyte columns.'"
+        )
+    )
+    op.execute(
+        text(
+            "CREATE UNIQUE INDEX ux_ogc_major_chemistry_results_id "
+            "ON ogc_major_chemistry_results (id)"
+        )
+    )
+
+    _drop_view_or_materialized_view("ogc_minor_chemistry_wells")
+    op.execute(text(_create_minor_chemistry_wells_view(public_only)))
+    op.execute(
+        text(
+            "COMMENT ON MATERIALIZED VIEW ogc_minor_chemistry_wells IS "
+            "'Latest minor/trace chemistry analyte values for water wells, pivoted into static analyte columns.'"
+        )
+    )
+    op.execute(
+        text(
+            "CREATE UNIQUE INDEX ux_ogc_minor_chemistry_wells_id "
+            "ON ogc_minor_chemistry_wells (id)"
+        )
+    )
+
+    _drop_view_or_materialized_view("ogc_water_elevation_wells")
+    op.execute(text(_create_water_elevation_view(public_only)))
+    op.execute(
+        text(
+            "COMMENT ON MATERIALIZED VIEW ogc_water_elevation_wells IS "
+            "'Latest water elevation per well with explicit units: "
+            "elevation_m, depth_to_water_below_ground_surface_ft, water_elevation_ft.'"
+        )
+    )
+    op.execute(
+        text(
+            "CREATE UNIQUE INDEX ux_ogc_water_elevation_wells_id "
+            "ON ogc_water_elevation_wells (id)"
+        )
+    )
+
+    # Recreate now that ogc_water_well_summary exists again.
+    op.execute(text(_create_actively_monitored_wells_view()))
+    op.execute(
+        text(
+            "COMMENT ON VIEW ogc_actively_monitored_wells IS "
+            "'Wells in the Water Level Network group for pygeoapi.'"
+        )
+    )
+
+    _drop_view_or_materialized_view("ogc_project_areas")
+    op.execute(text(_create_project_areas_view(public_only)))
+    op.execute(
+        text(
+            "COMMENT ON VIEW ogc_project_areas IS "
+            "'Project areas for groups with polygon boundaries for pygeoapi.'"
+        )
+    )
+
+
+def upgrade() -> None:
+    _check_required_tables()
+    _recreate_governed_views(public_only=True)
+
+    # ogc_locations does not exist before this migration -- see module
+    # docstring. Only ever created in its filtered form.
+    _drop_view_or_materialized_view("ogc_locations")
+    op.execute(text(_create_locations_view()))
+    op.execute(
+        text(
+            "COMMENT ON VIEW ogc_locations IS "
+            "'Public locations for pygeoapi, replacing the raw location table provider.'"
+        )
+    )
+
+
+def downgrade() -> None:
+    _recreate_governed_views(public_only=False)
+
+    # ogc_locations never existed unfiltered in production; downgrading
+    # drops it rather than recreating an unfiltered copy.
+    _drop_view_or_materialized_view("ogc_locations")

--- a/alembic/versions/f4a5b6c7d8e9_apply_public_release_status_filter_to_ogc_views.py
+++ b/alembic/versions/f4a5b6c7d8e9_apply_public_release_status_filter_to_ogc_views.py
@@ -23,8 +23,16 @@ unfiltered in production, downgrade() drops it rather than recreating an
 unfiltered copy.
 
 Revision ID: f4a5b6c7d8e9
-Revises: y3z4a5b6c7d8
+Revises: b6c7d8e9f0a1
 Create Date: 2026-07-14 00:00:00.000000
+
+Re-pointed from the original y3z4a5b6c7d8 on 2026-08-03: three colleague
+migrations (z9a0b1c2d3e4, a5b6c7d8e9f0, b6c7d8e9f0a1) landed on staging off
+that same revision while this branch was still open, forking the history.
+Neither touches anything this migration's SQL depends on -- the two new EDR
+views (z9a0b1c2d3e4) already filter on release_status = 'public' themselves,
+and the other two only touch the unrelated NMW measurement views and
+pg_cron scheduling.
 """
 
 import re
@@ -35,7 +43,7 @@ from sqlalchemy import inspect, text
 
 # revision identifiers, used by Alembic.
 revision: str = "f4a5b6c7d8e9"
-down_revision: Union[str, Sequence[str], None] = "y3z4a5b6c7d8"
+down_revision: Union[str, Sequence[str], None] = "b6c7d8e9f0a1"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/core/pygeoapi-config.yml
+++ b/core/pygeoapi-config.yml
@@ -54,7 +54,7 @@ resources:
           password: {postgres_password_env}
           search_path: [public]
         id_field: id
-        table: location
+        table: ogc_locations
         geom_field: point
 
   latest_depth_to_water_wells:

--- a/data_migrations/migrations/20260714_0001_publish_project_areas.py
+++ b/data_migrations/migrations/20260714_0001_publish_project_areas.py
@@ -1,0 +1,44 @@
+# ===============================================================================
+# Copyright 2026 ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+from sqlalchemy import update
+from sqlalchemy.orm import Session
+
+from data_migrations.base import DataMigration
+from db.group import Group
+
+
+def run(session: Session) -> None:
+    session.execute(
+        update(Group)
+        .where(Group.project_area.isnot(None))
+        .values(release_status="public")
+    )
+    session.commit()
+
+
+MIGRATION = DataMigration(
+    id="20260714_0001_publish_project_areas",
+    alembic_revision="f4a5b6c7d8e9",
+    name="Publish all project_areas records",
+    description=(
+        "Marks every group record backing the project_areas OGC layer "
+        "(project_area IS NOT NULL) as release_status='public'. Confirmed "
+        "via docs/ogc-layer-audit.md that all 56 current rows are "
+        "release_status='draft'."
+    ),
+    run=run,
+    is_repeatable=False,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dependencies = [
 package = true
 
 [tool.setuptools]
-packages = ["alembic", "cli", "core", "db", "schemas", "services", "transfers"]
+packages = ["alembic", "cli", "core", "data_migrations", "db", "schemas", "services", "transfers"]
 
 [project.scripts]
 oco = "cli.cli:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ dependencies = [
 package = true
 
 [tool.setuptools]
-packages = ["alembic", "cli", "core", "db", "schemas", "services", "transfers"]
+packages = ["alembic", "cli", "core", "data_migrations", "db", "schemas", "services", "transfers"]
 
 [project.scripts]
 oco = "cli.cli:cli"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,7 @@ def location():
             point="POINT(-107.949533 33.809665)",
             elevation=2464.9,
             county="Sierra",
-            release_status="draft",
+            release_status="public",
             state="NM",
             quad_name="Hillsboro Peak",
         )
@@ -182,7 +182,7 @@ def water_well_thing(location):
             name="Test Well",
             first_visit_date="2023-03-03",
             thing_type="water well",
-            release_status="draft",
+            release_status="public",
             well_depth=10,
             hole_depth=10,
             well_casing_diameter=5.0,
@@ -1041,7 +1041,7 @@ def observation_to_delete(water_chemistry_sample, sensor):
 def group(water_well_thing):
     with session_ctx() as session:
         group = Group(
-            release_status="draft",
+            release_status="public",
             name="Test Group",
             description="This is a test group.",
             project_area="MULTIPOLYGON(((-107.2 33.6, -106.6 33.6, -106.6 34.2, -107.2 34.2, -107.2 33.6)))",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,7 +132,7 @@ def location():
             point="POINT(-107.949533 33.809665)",
             elevation=2464.9,
             county="Sierra",
-            release_status="draft",
+            release_status="public",
             state="NM",
             quad_name="Hillsboro Peak",
         )
@@ -180,7 +180,7 @@ def water_well_thing(location):
             name="Test Well",
             first_visit_date="2023-03-03",
             thing_type="water well",
-            release_status="draft",
+            release_status="public",
             well_depth=10,
             hole_depth=10,
             well_casing_diameter=5.0,
@@ -1039,7 +1039,7 @@ def observation_to_delete(water_chemistry_sample, sensor):
 def group(water_well_thing):
     with session_ctx() as session:
         group = Group(
-            release_status="draft",
+            release_status="public",
             name="Test Group",
             description="This is a test group.",
             project_area="MULTIPOLYGON(((-107.2 33.6, -106.6 33.6, -106.6 34.2, -107.2 34.2, -107.2 33.6)))",

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -832,10 +832,19 @@ def after_all(context):
 def before_scenario(context, scenario):
     # runs before EVERY scenario
     # e.g. reset test data, open browser, etc.
-    pass
+    if "migration-mutates-schema" in scenario.tags:
+        # Defense in depth against a previous, unrelated failure having
+        # already left the database below head.
+        command.upgrade(_alembic_config(), "head")
 
 
 def after_scenario(context, scenario):
+    if "migration-mutates-schema" in scenario.tags:
+        # Runs whether the scenario passed or failed, so a downgrade left
+        # mid-scenario never leaks into later scenarios/features sharing
+        # this database. Deliberately not gated on DROP_AND_REBUILD_DB,
+        # since these scenarios mutate schema regardless of that flag.
+        command.upgrade(_alembic_config(), "head")
 
     if not get_bool_env("DROP_AND_REBUILD_DB"):
         return

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -741,10 +741,19 @@ def after_all(context):
 def before_scenario(context, scenario):
     # runs before EVERY scenario
     # e.g. reset test data, open browser, etc.
-    pass
+    if "migration-mutates-schema" in scenario.tags:
+        # Defense in depth against a previous, unrelated failure having
+        # already left the database below head.
+        command.upgrade(_alembic_config(), "head")
 
 
 def after_scenario(context, scenario):
+    if "migration-mutates-schema" in scenario.tags:
+        # Runs whether the scenario passed or failed, so a downgrade left
+        # mid-scenario never leaks into later scenarios/features sharing
+        # this database. Deliberately not gated on DROP_AND_REBUILD_DB,
+        # since these scenarios mutate schema regardless of that flag.
+        command.upgrade(_alembic_config(), "head")
 
     if not get_bool_env("DROP_AND_REBUILD_DB"):
         return

--- a/tests/features/ogc-cleanup-sprint1.feature
+++ b/tests/features/ogc-cleanup-sprint1.feature
@@ -25,13 +25,13 @@ Feature: OGC Feature Layer Cleanup — Sprint 1
   # A1 — Apply release_status = 'public' filter to all OGC views
   # ---------------------------------------------------------------------------
 
-  @backend @ogc-exposure @sprint-1 @high-priority @A1
+  @backend @ogc-exposure @sprint-1 @high-priority @A1 @production @migration-mutates-schema @cleanup_samples
   Scenario: Sprint 1 migration restricts all ogc_* views to public records
     Given a clean database state before the Sprint 1 migration
     When the Sprint 1 Alembic migration is applied
     Then each ogc_* view returns only records with release_status "public"
 
-  @backend @ogc-exposure @sprint-1 @high-priority @A1
+  @backend @ogc-exposure @sprint-1 @high-priority @A1 @production @migration-mutates-schema @cleanup_samples
   Scenario: Sprint 1 migration can be reversed without error
     Given the Sprint 1 migration has been applied
     When the Sprint 1 migration downgrade is run
@@ -40,7 +40,7 @@ Feature: OGC Feature Layer Cleanup — Sprint 1
     And each ogc_* view returns the same count of draft records as before the migration
     And no database errors are raised
 
-  @backend @ogc-exposure @sprint-1 @high-priority @A1
+  @backend @ogc-exposure @sprint-1 @high-priority @A1 @production @cleanup_samples
   Scenario: Non-public records are excluded from every exposure-affected OGC layer
     Given the Sprint 1 migration has been applied
     When a public client requests items from each of the following layers:
@@ -69,15 +69,22 @@ Feature: OGC Feature Layer Cleanup — Sprint 1
     # other_things above: A1 must apply the filter to its view, but A18 removes
     # other_things from the catalog — run this scenario before A18 is applied
 
-  @backend @ogc-exposure @sprint-1 @high-priority @A1
+  @backend @ogc-exposure @sprint-1 @high-priority @A1 @production
   Scenario: project_areas returns 56 rows after all records are updated to public
     Given all 56 project_areas records have been updated from release_status "draft" to release_status "public"
     When a client requests features from the project_areas layer
     Then the response contains 56 features
     And the response HTTP status is 200
     And all returned features have release_status "public"
+    # The "Given" precondition above is satisfied by a dedicated data
+    # migration (not the schema migration that adds the release_status
+    # filter) -- see the project_areas data migration in this ticket's
+    # implementation. Automated tests verify the underlying property
+    # (every project_area-bearing group ends up public), not the literal
+    # count 56, which is specific to today's real production data and is
+    # spot-checked manually against the target environment instead.
 
-  @backend @ogc-exposure @sprint-1 @high-priority @A1
+  @backend @ogc-exposure @sprint-1 @high-priority @A1 @production @migration-mutates-schema @cleanup_samples
   Scenario: The 4 already-consistent layers are unaffected by the migration
     Given the following layers were already filtering correctly before the migration:
       | layer-id                        |

--- a/tests/features/steps/ogc-cleanup-sprint1.py
+++ b/tests/features/steps/ogc-cleanup-sprint1.py
@@ -1,0 +1,672 @@
+# ===============================================================================
+# Copyright 2026 ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""Step definitions for A1 (public release_status filter on ogc_* views).
+
+Only the @A1-tagged scenarios in ogc-cleanup-sprint1.feature are implemented
+here. The other ~10 tickets sharing that feature file have no steps yet and
+stay undefined/dormant, per this ticket's plan.
+"""
+import importlib
+from datetime import date
+
+from alembic import command
+from behave import given, when, then
+from sqlalchemy import text
+
+from core.dependencies import (
+    viewer_function,
+    amp_viewer_function,
+    amp_editor_function,
+    admin_function,
+    amp_admin_function,
+)
+from starlette.testclient import TestClient
+
+from db import (
+    Location,
+    Thing,
+    LocationThingAssociation,
+    Group,
+    GroupThingAssociation,
+    StatusHistory,
+    Contact,
+    FieldEvent,
+    FieldEventParticipant,
+    FieldActivity,
+    Sample,
+    Observation,
+    Sensor,
+    NMA_Chemistry_SampleInfo,
+    NMA_MajorChemistry,
+    NMA_MinorTraceChemistry,
+)
+from db.engine import session_ctx
+from tests import get_parameter_id
+from tests.features.environment import _alembic_config
+
+# Revision immediately before this ticket's schema migration -- re-verify
+# with `alembic heads`/`alembic history` if this file is revisited later,
+# since new migrations may have landed since.
+PRE_A1_REVISION = "y3z4a5b6c7d8"
+
+# Maps every OGC layer-id used in this feature file's data tables to the
+# seed group whose known public/private/draft ids should appear or not
+# appear in that layer. The 9 derived/summary layers and
+# actively_monitored_wells all key off the same seeded water wells.
+LAYER_ID_TO_SEED_KEY = {
+    "water_wells": "water_wells",
+    "springs": "springs",
+    "perennial_streams": "perennial_streams",
+    "meteorological_stations": "meteorological_stations",
+    "diversions_surface_water": "diversions_surface_water",
+    "lakes_ponds_reservoirs": "lakes_ponds_reservoirs",
+    "other_things": "other_things",
+    "water_well_summary": "water_wells",
+    "depth_to_water_trend_wells": "water_wells",
+    "water_elevation_wells": "water_wells",
+    "major_chemistry_results": "water_wells",
+    "minor_chemistry_wells": "water_wells",
+    "latest_tds_wells": "water_wells",
+    "actively_monitored_wells": "water_wells",
+    "avg_tds_wells": "water_wells",
+    "latest_depth_to_water_wells": "water_wells",
+    "locations": "locations",
+    "project_areas": "project_areas",
+    "ephemeral_streams": "ephemeral_streams",
+    "rock_sample_locations": "rock_sample_locations",
+    "soil_gas_sample_locations": "soil_gas_sample_locations",
+    "outfalls_wastewater_return_flow": "outfalls_wastewater_return_flow",
+}
+
+# Same mapping, keyed by the underlying ogc_* relation name, for the
+# SQL-level scenarios (migration-application, downgrade-reversibility).
+VIEW_TO_SEED_KEY = {
+    f"ogc_{layer_id}": seed_key for layer_id, seed_key in LAYER_ID_TO_SEED_KEY.items()
+}
+
+# ogc_locations does not exist before A1 (core/pygeoapi-config.yml pointed
+# directly at the raw location table), so downgrade drops it rather than
+# recreating an unfiltered copy -- there is no "count before the migration"
+# to compare it against once downgraded.
+NOT_PRESENT_BEFORE_A1 = {"ogc_locations"}
+
+# Thing-type layers backed by the shared _create_thing_view template --
+# a simple Location + Thing pair is enough to exercise these.
+SIMPLE_THING_TYPE_LAYERS = [
+    ("springs", "spring"),
+    ("perennial_streams", "perennial stream"),
+    ("meteorological_stations", "meteorological station"),
+    ("diversions_surface_water", "diversion of surface water, etc."),
+    ("lakes_ponds_reservoirs", "lake, pond or reservoir"),
+    ("other_things", "other"),
+    ("ephemeral_streams", "ephemeral stream"),
+    ("rock_sample_locations", "rock sample location"),
+    ("soil_gas_sample_locations", "soil gas sample location"),
+    ("outfalls_wastewater_return_flow", "outfall of wastewater or return flow"),
+]
+
+# The feature file's "4 already-consistent layers" scenario: today's live
+# data for these thing types happens to be 100% public already.
+ALREADY_CONSISTENT_LAYER_IDS = {
+    "ephemeral_streams",
+    "rock_sample_locations",
+    "soil_gas_sample_locations",
+    "outfalls_wastewater_return_flow",
+}
+
+STATUSES = ("public", "private", "draft")
+
+
+@given("the Ocotillo API is running")
+def step_given_ocotillo_api_is_running(context):
+    from main import app
+
+    def override_authentication(default=True):
+        def closure():
+            return default
+
+        return closure
+
+    app.dependency_overrides[amp_admin_function] = override_authentication(
+        default={"name": "foobar", "sub": "1234567890"}
+    )
+    app.dependency_overrides[admin_function] = override_authentication(
+        default={"name": "foobar", "sub": "1234567890"}
+    )
+    app.dependency_overrides[amp_editor_function] = override_authentication(
+        default={"name": "foobar", "sub": "1234567890"}
+    )
+    app.dependency_overrides[amp_viewer_function] = override_authentication()
+    app.dependency_overrides[viewer_function] = override_authentication()
+
+    context.client = TestClient(app)
+    assert context.client is not None, "TestClient failed to initialize"
+
+
+def _seed_thing_with_location(session, thing_type, release_status, name):
+    location = Location(
+        point="POINT(-106.5 34.0)",
+        elevation=1500.0,
+        release_status="public",
+    )
+    session.add(location)
+    session.commit()
+
+    thing = Thing(
+        name=name,
+        first_visit_date="2023-01-01",
+        thing_type=thing_type,
+        release_status=release_status,
+    )
+    session.add(thing)
+    session.commit()
+
+    assoc = LocationThingAssociation(location=location, thing=thing)
+    assoc.effective_start = "2023-01-01T00:00:00Z"
+    session.add(assoc)
+    session.commit()
+    session.refresh(thing)
+    return thing
+
+
+def _seed_water_well(session, release_status, name, monitoring_group):
+    well = _seed_thing_with_location(session, "water well", release_status, name)
+    # well.id is used to keep every unique-constrained field below distinct
+    # across repeated _seed_all() calls within the same behave run (this
+    # helper runs once per A1 scenario, sharing one database).
+    uid = well.id
+
+    # Observation chain feeding ogc_latest_depth_to_water_wells,
+    # ogc_depth_to_water_trend_wells, ogc_water_well_summary,
+    # ogc_water_elevation_wells.
+    contact = Contact(
+        name=f"A1 Contact {uid}",
+        role="Owner",
+        contact_type="Primary",
+        organization="NMBGMR",
+        release_status="draft",
+    )
+    session.add(contact)
+    session.commit()
+
+    field_event = FieldEvent(
+        thing_id=well.id,
+        event_date="2025-01-01T00:00:00Z",
+        notes="A1 behave seed field event",
+        release_status="draft",
+    )
+    session.add(field_event)
+    session.commit()
+
+    participant = FieldEventParticipant(
+        field_event_id=field_event.id,
+        contact_id=contact.id,
+        participant_role="Lead",
+    )
+    session.add(participant)
+    session.commit()
+
+    field_activity = FieldActivity(
+        field_event_id=field_event.id,
+        activity_type="groundwater level",
+        notes="A1 behave seed field activity",
+        release_status="draft",
+    )
+    session.add(field_activity)
+    session.commit()
+
+    sample = Sample(
+        field_activity_id=field_activity.id,
+        field_event_participant_id=participant.id,
+        sample_date="2025-01-01T12:00:00Z",
+        sample_name=f"A1 sample {uid}",
+        sample_matrix="water",
+        sample_method="Steel-tape measurement",
+        qc_type="Normal",
+        depth_top=None,
+        depth_bottom=None,
+        notes="A1 behave seed sample",
+        release_status="draft",
+    )
+    session.add(sample)
+    session.commit()
+
+    sensor = Sensor(
+        name=f"A1 Sensor {uid}",
+        sensor_type="Pressure Transducer",
+        model="Model X",
+        serial_no=f"A1-SN-{uid}",
+        pcn_number=f"A1-PCN-{uid}",
+        owner_agency="NMBGMR",
+        sensor_status="In Service",
+        notes="A1 behave seed sensor",
+        release_status="draft",
+    )
+    session.add(sensor)
+    session.commit()
+
+    observation = Observation(
+        observation_datetime="2025-01-01T00:04:00Z",
+        sample_id=sample.id,
+        sensor_id=sensor.id,
+        parameter_id=get_parameter_id("groundwater level", "Field Parameter"),
+        release_status="draft",
+        value=10.0,
+        unit="ft",
+        measuring_point_height=5.0,
+        groundwater_level_reason="Water level not affected",
+    )
+    session.add(observation)
+    session.commit()
+
+    # Chemistry rows feeding ogc_avg_tds_wells, ogc_latest_tds_wells,
+    # ogc_major_chemistry_results, ogc_minor_chemistry_wells.
+    # nma_sample_point_id is varchar(10) -- keep it short.
+    sample_point_id = f"A1{uid}"[:10]
+    csi = NMA_Chemistry_SampleInfo(
+        thing_id=well.id,
+        nma_sample_point_id=sample_point_id,
+        collection_date="2025-01-02T10:00:00Z",
+    )
+    session.add(csi)
+    session.flush()
+
+    major = NMA_MajorChemistry(
+        chemistry_sample_info_id=csi.id,
+        analyte="Total Dissolved Solids",
+        symbol="TDS",
+        sample_value=500.0,
+        units="mg/L",
+        analysis_date=None,
+    )
+    session.add(major)
+
+    minor = NMA_MinorTraceChemistry(
+        chemistry_sample_info_id=csi.id,
+        nma_sample_point_id=sample_point_id,
+        analyte="F",
+        symbol="",
+        sample_value=1.0,
+        units="mg/L",
+        analysis_date=date(2025, 1, 2),
+    )
+    session.add(minor)
+    session.commit()
+
+    # Water Level Network membership feeding ogc_actively_monitored_wells.
+    group_assoc = GroupThingAssociation(group_id=monitoring_group.id, thing_id=well.id)
+    session.add(group_assoc)
+    status_history = StatusHistory(
+        status_type="Monitoring Status",
+        status_value="Currently monitored",
+        start_date=date(2024, 1, 1),
+        end_date=None,
+        reason="A1 behave seed status",
+        target_id=well.id,
+        target_table="thing",
+    )
+    session.add(status_history)
+    session.commit()
+
+    return well
+
+
+def _seed_all(session):
+    """Seed one public/private/draft row per relevant thing type, one
+    draft Group with a project_area, and one standalone Location per
+    status. Returns {seed_key: {"public": id, "private": id, "draft": id}}.
+    """
+    seed_ids = {}
+
+    monitoring_group = Group(
+        name="Water Level Network",
+        description="A1 behave seed monitoring group",
+        release_status="public",
+    )
+    session.add(monitoring_group)
+    session.commit()
+
+    for layer_id, thing_type in SIMPLE_THING_TYPE_LAYERS:
+        seed_ids[layer_id] = {}
+        for status in STATUSES:
+            thing = _seed_thing_with_location(
+                session, thing_type, status, f"A1 {layer_id} {status}"
+            )
+            seed_ids[layer_id][status] = thing.id
+
+    seed_ids["water_wells"] = {}
+    for status in STATUSES:
+        well = _seed_water_well(
+            session, status, f"A1 water well {status}", monitoring_group
+        )
+        seed_ids["water_wells"][status] = well.id
+
+    seed_ids["project_areas"] = {}
+    for status in STATUSES:
+        group = Group(
+            name=f"A1 project area {status}",
+            description="A1 behave seed project area group",
+            release_status=status,
+            project_area=(
+                "MULTIPOLYGON(((-107.2 33.6, -106.6 33.6, "
+                "-106.6 34.2, -107.2 34.2, -107.2 33.6)))"
+            ),
+        )
+        session.add(group)
+        session.commit()
+        seed_ids["project_areas"][status] = group.id
+
+    seed_ids["locations"] = {}
+    for status in STATUSES:
+        location = Location(
+            point="POINT(-106.0 34.5)",
+            elevation=1600.0,
+            release_status=status,
+        )
+        session.add(location)
+        session.commit()
+        seed_ids["locations"][status] = location.id
+
+    # Materialized views are snapshots, not live queries -- the newly
+    # seeded rows are invisible to them until refreshed.
+    session.execute(text("SELECT public.refresh_materialized_views()"))
+    session.commit()
+
+    return seed_ids
+
+
+def _teardown_a1_seed_data():
+    """Delete every row these scenarios seed, by naming convention.
+
+    Without this, Thing/Group rows from an earlier A1 scenario in the same
+    behave run leak into a later scenario's absolute feature-count checks
+    (e.g. the already-consistent-layers scenario). Registered via
+    context.add_cleanup so it runs after the scenario regardless of
+    pass/fail, without needing an environment.py hook.
+    """
+    with session_ctx() as session:
+        session.execute(text("DELETE FROM thing WHERE name LIKE 'A1 %'"))
+        session.execute(
+            text(
+                "DELETE FROM \"group\" WHERE name LIKE 'A1 %' OR name = 'Water Level Network'"
+            )
+        )
+        session.commit()
+
+
+def _ensure_head(context):
+    command.upgrade(_alembic_config(), "head")
+    with session_ctx() as session:
+        context.seed_ids = _seed_all(session)
+    context.add_cleanup(_teardown_a1_seed_data)
+
+
+@given("a clean database state before the Sprint 1 migration")
+def step_given_clean_database_state(context):
+    command.downgrade(_alembic_config(), PRE_A1_REVISION)
+    with session_ctx() as session:
+        context.seed_ids = _seed_all(session)
+    context.add_cleanup(_teardown_a1_seed_data)
+
+
+@when("the Sprint 1 Alembic migration is applied")
+def step_when_sprint1_alembic_migration_is_applied(context):
+    command.upgrade(_alembic_config(), "head")
+
+
+@then('each ogc_* view returns only records with release_status "public"')
+def step_then_views_are_public_only(context):
+    with session_ctx() as session:
+        for relation, seed_key in VIEW_TO_SEED_KEY.items():
+            ids = context.seed_ids[seed_key]
+            for status in ("private", "draft"):
+                count = session.execute(
+                    text(f"SELECT COUNT(*) FROM {relation} WHERE id = :id"),
+                    {"id": ids[status]},
+                ).scalar()
+                assert count == 0, (
+                    f"{relation} exposed a {status} row (id={ids[status]}) "
+                    "that should have been filtered out"
+                )
+            public_count = session.execute(
+                text(f"SELECT COUNT(*) FROM {relation} WHERE id = :id"),
+                {"id": ids["public"]},
+            ).scalar()
+            assert public_count == 1, f"{relation} is missing its public seed row"
+
+
+@given("the Sprint 1 migration has been applied")
+def step_given_sprint1_migration_has_been_applied(context):
+    _ensure_head(context)
+
+
+@when("the Sprint 1 migration downgrade is run")
+def step_when_sprint1_migration_downgrade_is_run(context):
+    context.downgrade_error = None
+    try:
+        command.downgrade(_alembic_config(), PRE_A1_REVISION)
+    except Exception as exc:  # noqa: BLE001 -- surfaced via the next Then step
+        context.downgrade_error = exc
+
+
+@then(
+    "each ogc_* view returns the same count of {status} records as before the migration"
+)
+def step_then_same_count_as_before_migration(context, status):
+    assert (
+        context.downgrade_error is None
+    ), f"Downgrade raised an error before counts could be checked: {context.downgrade_error}"
+    with session_ctx() as session:
+        for relation, seed_key in VIEW_TO_SEED_KEY.items():
+            if relation in NOT_PRESENT_BEFORE_A1:
+                continue
+            ids = context.seed_ids[seed_key]
+            count = session.execute(
+                text(f"SELECT COUNT(*) FROM {relation} WHERE id = :id"),
+                {"id": ids[status]},
+            ).scalar()
+            assert count == 1, (
+                f"{relation}: expected the seeded {status} row to be visible again "
+                f"after downgrade (pre-A1 had no filter), got count={count}"
+            )
+
+
+@then("no database errors are raised")
+def step_then_no_database_errors_are_raised(context):
+    assert (
+        context.downgrade_error is None
+    ), f"Downgrade raised: {context.downgrade_error}"
+    # Restore head immediately so later scenarios/features never run against
+    # a downgraded schema even if a later step in this scenario fails.
+    command.upgrade(_alembic_config(), "head")
+
+
+def _get_items(context, layer_id, limit=200):
+    response = context.client.get(f"/ogcapi/collections/{layer_id}/items?limit={limit}")
+    assert (
+        response.status_code == 200
+    ), f"Unexpected status {response.status_code} for layer {layer_id}: {response.text}"
+    return response.json()
+
+
+@when("a public client requests items from each of the following layers:")
+def step_when_public_client_requests_items_from_layers(context):
+    context.layer_responses = {}
+    for row in context.table:
+        layer_id = row["layer-id"].strip()
+        context.layer_responses[layer_id] = _get_items(context, layer_id)
+
+
+def _layer_feature_ids(payload):
+    ids = set()
+    for feature in payload["features"]:
+        feature_id = feature.get("id", feature.get("properties", {}).get("id"))
+        ids.add(feature_id)
+    return ids
+
+
+@then('each response contains only records where release_status is "public"')
+def step_then_each_response_contains_only_public(context):
+    for layer_id, payload in context.layer_responses.items():
+        seed_key = LAYER_ID_TO_SEED_KEY[layer_id]
+        features = payload["features"]
+        if features and "release_status" in features[0]["properties"]:
+            for feature in features:
+                assert (
+                    feature["properties"]["release_status"] == "public"
+                ), f"{layer_id} returned a non-public record: {feature['properties']}"
+        else:
+            ids_present = _layer_feature_ids(payload)
+            public_id = context.seed_ids[seed_key]["public"]
+            assert (
+                public_id in ids_present
+            ), f"{layer_id} is missing its public seed row"
+
+
+@then('no response contains a record where release_status is "{status}"')
+def step_then_no_response_contains_status(context, status):
+    for layer_id, payload in context.layer_responses.items():
+        seed_key = LAYER_ID_TO_SEED_KEY[layer_id]
+        features = payload["features"]
+        if features and "release_status" in features[0]["properties"]:
+            for feature in features:
+                assert (
+                    feature["properties"]["release_status"] != status
+                ), f"{layer_id} returned a {status} record: {feature['properties']}"
+        else:
+            ids_present = _layer_feature_ids(payload)
+            excluded_id = context.seed_ids[seed_key][status]
+            assert (
+                excluded_id not in ids_present
+            ), f"{layer_id} exposed its seeded {status} row (id={excluded_id})"
+
+
+@given(
+    'all 56 project_areas records have been updated from release_status "draft" to release_status "public"'
+)
+def step_given_56_project_areas_updated_to_public(context):
+    publish_project_areas = importlib.import_module(
+        "data_migrations.migrations.20260714_0001_publish_project_areas"
+    )
+    command.upgrade(_alembic_config(), "head")
+    with session_ctx() as session:
+        groups = [
+            Group(
+                name=f"A1 56-count project area {i}",
+                description="A1 behave seed project area for the 56-row scenario",
+                release_status="draft",
+                project_area=(
+                    "MULTIPOLYGON(((-107.0 33.0, -106.9 33.0, "
+                    "-106.9 33.1, -107.0 33.1, -107.0 33.0)))"
+                ),
+            )
+            for i in range(56)
+        ]
+        session.add_all(groups)
+        session.commit()
+        context.project_area_group_ids = [g.id for g in groups]
+
+        publish_project_areas.run(session)
+
+
+@when("a client requests features from the project_areas layer")
+def step_when_client_requests_project_areas(context):
+    context.response = context.client.get(
+        "/ogcapi/collections/project_areas/items?limit=1000"
+    )
+
+
+@then("the response contains {count:d} features")
+def step_then_response_contains_n_features(context, count):
+    payload = context.response.json()
+    matching = [
+        f
+        for f in payload["features"]
+        if f.get("id", f.get("properties", {}).get("id"))
+        in set(context.project_area_group_ids)
+    ]
+    assert len(matching) == count, (
+        f"Expected {count} of this scenario's seeded project_areas features, "
+        f"found {len(matching)}"
+    )
+
+
+@then("the response HTTP status is {status:d}")
+def step_then_response_http_status_is(context, status):
+    assert (
+        context.response.status_code == status
+    ), f"Unexpected status {context.response.status_code}, expected {status}"
+
+
+@then('all returned features have release_status "public"')
+def step_then_all_returned_features_are_public(context):
+    payload = context.response.json()
+    for feature in payload["features"]:
+        if feature.get("id", feature.get("properties", {}).get("id")) not in set(
+            context.project_area_group_ids
+        ):
+            continue
+        assert (
+            feature["properties"]["release_status"] == "public"
+        ), f"Feature {feature.get('id')} was not public: {feature['properties']}"
+
+
+def _seed_already_consistent_layers(session):
+    """These 4 layers are asserted to be 100% public today -- unlike
+    _seed_all(), only public rows are seeded here. Seeding private/draft
+    rows into them would defeat the point of this scenario: proving the
+    filter changes nothing because there was never anything to filter.
+    """
+    for layer_id, thing_type in SIMPLE_THING_TYPE_LAYERS:
+        if layer_id not in ALREADY_CONSISTENT_LAYER_IDS:
+            continue
+        for i in range(3):
+            _seed_thing_with_location(
+                session, thing_type, "public", f"A1 already-consistent {layer_id} {i}"
+            )
+
+
+@given("the following layers were already filtering correctly before the migration:")
+def step_given_already_consistent_layers(context):
+    command.downgrade(_alembic_config(), PRE_A1_REVISION)
+    with session_ctx() as session:
+        _seed_already_consistent_layers(session)
+        session.commit()
+    context.add_cleanup(_teardown_a1_seed_data)
+
+    context.already_consistent_counts = {}
+    for row in context.table:
+        layer_id = row["layer-id"].strip()
+        payload = _get_items(context, layer_id, limit=500)
+        context.already_consistent_counts[layer_id] = len(payload["features"])
+
+
+@when("the Sprint 1 migration is applied")
+def step_when_sprint1_migration_is_applied(context):
+    command.upgrade(_alembic_config(), "head")
+
+
+@then("each of those layers returns the same feature count as before the migration")
+def step_then_same_feature_count_as_before(context):
+    for layer_id, before_count in context.already_consistent_counts.items():
+        payload = _get_items(context, layer_id, limit=500)
+        after_count = len(payload["features"])
+        assert (
+            after_count == before_count
+        ), f"{layer_id}: expected {before_count} features (unchanged), got {after_count}"
+
+
+# ============= EOF =============================================

--- a/tests/features/steps/ogc-cleanup-sprint1.py
+++ b/tests/features/steps/ogc-cleanup-sprint1.py
@@ -19,6 +19,7 @@ Only the @A1-tagged scenarios in ogc-cleanup-sprint1.feature are implemented
 here. The other ~10 tickets sharing that feature file have no steps yet and
 stay undefined/dormant, per this ticket's plan.
 """
+
 import importlib
 from datetime import date
 

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -20,8 +20,12 @@ from sqlalchemy import select
 move_notes = importlib.import_module(
     "data_migrations.migrations.20260205_0001_move_nma_location_notes"
 )
+publish_project_areas = importlib.import_module(
+    "data_migrations.migrations.20260714_0001_publish_project_areas"
+)
 from db.location import Location
 from db.notes import Notes
+from db.group import Group
 from db.engine import session_ctx
 
 
@@ -104,4 +108,34 @@ def test_move_nma_location_notes_skips_duplicates():
 
         session.delete(notes[0])
         session.delete(location)
+        session.commit()
+
+
+def test_publish_project_areas_marks_project_area_groups_public():
+    with session_ctx() as session:
+        draft_with_area = Group(
+            name="Draft Project Area A",
+            description="Has a project area, should be published.",
+            release_status="draft",
+            project_area="MULTIPOLYGON(((-107.2 33.6, -106.6 33.6, -106.6 34.2, -107.2 34.2, -107.2 33.6)))",
+        )
+        draft_without_area = Group(
+            name="Draft No Area",
+            description="No project area, should be left alone.",
+            release_status="draft",
+        )
+        session.add_all([draft_with_area, draft_without_area])
+        session.commit()
+        session.refresh(draft_with_area)
+        session.refresh(draft_without_area)
+
+        publish_project_areas.run(session)
+
+        session.refresh(draft_with_area)
+        session.refresh(draft_without_area)
+        assert draft_with_area.release_status == "public"
+        assert draft_without_area.release_status == "draft"
+
+        session.delete(draft_with_area)
+        session.delete(draft_without_area)
         session.commit()

--- a/tests/test_geospatial.py
+++ b/tests/test_geospatial.py
@@ -117,7 +117,7 @@ def populate():
 
         session.add(group)
         session.commit()
-        yield
+        yield group
 
         # Cleanup
         session.delete(loc1)
@@ -128,15 +128,15 @@ def populate():
         session.commit()
 
 
-def test_get_project_area():
-    response = client.get("/geospatial/project-area/1")
+def test_get_project_area(populate):
+    response = client.get(f"/geospatial/project-area/{populate.id}")
     assert response.status_code == 200
     data = response.json()
     assert "type" in data
     assert data["type"] == "FeatureCollection"
     assert "features" in data
     assert len(data["features"]) > 0
-    assert data["features"][0]["properties"]["group_id"] == 1
+    assert data["features"][0]["properties"]["group_id"] == populate.id
     assert data["features"][0]["properties"]["group_name"] == "Test Group Foo"
     assert (
         data["features"][0]["properties"]["group_description"]

--- a/tests/test_ogc.py
+++ b/tests/test_ogc.py
@@ -413,7 +413,7 @@ def test_ogc_actively_monitored_wells_exposes_water_level_network_group_wells(
         group = Group(
             name="Water Level Network",
             group_type="Monitoring Plan",
-            release_status="draft",
+            release_status="public",
         )
         session.add(group)
         session.flush()
@@ -462,7 +462,7 @@ def test_ogc_actively_monitored_wells_excludes_latest_not_currently_monitored(
         group = Group(
             name="Water Level Network",
             group_type="Monitoring Plan",
-            release_status="draft",
+            release_status="public",
         )
         session.add(group)
         session.flush()


### PR DESCRIPTION
<!--
feat(ogc): filter ogc_* views to public records (BDMS-971 A1)
-->
## **Summary**
Restricts every `ogc_*` view/materialized view behind the public,
unauthenticated `/ogcapi` mount to `release_status = 'public'`, and flips the 56 `project_areas` rows (currently all `draft`) to `public`, so the newly-filtered `ogc_project_areas` view isn't left returning zero rows.

## **Why**
_This PR addresses the following problem / context:_
None of the 22 `ogc_*` relations filtered on `release_status`. They selected it, but never gated on it. Confirmed against live data: `water_wells` alone was serving 1,145 private + 140 draft rows alongside 8,678 public ones, and `project_areas` was 100% draft (56/56).

## **Changes**
_Implementation summary - the following was changed / added / removed:_
- **Public release_status filter**: new Alembic migration adds  `AND release_status = 'public'` to all 21 existing `ogc_*`  relations, and introduces `ogc_locations` (previously the  `locations` collection pointed straight at the raw `location`  table with no filter at all). `ogc_actively_monitored_wells` gets  no predicate of its own — it already inherits public-only rows  transitively through its join to `ogc_water_well_summary`. Fully  reversible: `downgrade()` restores the byte-identical unfiltered  SQL that was in production (`ogc_locations` is the one exception. I didn't exist pre-migration, so downgrade drops it instead).
- **`project_areas` publish migration**: companion data migration  (run via `oco data-migrations run`, not Alembic) flips the 56 `project_areas` group rows from `draft` to `public`. Forward-only by design, gated on this PR's schema revision having landed first.
- **Shared test fixtures**: required prerequisite: flips the shared `location`/`water_well_thing`/`group` fixtures from `draft` to `public`, since 9 existing tests assert those rows are visible through `ogc_*` responses.
- **Behave coverage**: new scenarios for the `@A1`-tagged cases in `ogc-cleanup-sprint1.feature` (migration application, downgrade reversibility, already-consistent layers, project_areas count).
- **`data_migrations` packaging**: `pyproject.toml`'s packages list was missing `data_migrations`, so the installed `oco` CLI couldn't import it at all. Pre-existing gap, unrelated to this ticket's logic, found while verifying `oco data-migrations run`.
- **Hardcoded test group id**: `test_get_project_area` assumed its fixture's `Group` would always get database id `1`, which only held because nothing else in the suite created a `Group` first. Surfaced by this PR's new data-migration test.


## **Verification**
- Full `pytest` suite: 716 passed, 0 failed.
- `alembic downgrade -1` / `upgrade head` cycle on a local test DB, with `psql` inspection confirming the filter predicate lands in the right place (including the innermost CTE for materialized views, not the outer query, per the DDL-ordering constraint for `ogc_actively_monitored_wells` → `ogc_water_well_summary`).
- `oco data-migrations run/status` round-trip for the project_areas migration.
- `behave --tags=@A1` — 5/5 scenarios passing.
- Manual smoke test against `/ogcapi/collections/*/items`.

## **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- Layer visibility (which collections are published) is unchanged. That's A16/A17/A18, separate tickets.
- **Before merging:** confirm the 56 `project_areas` rows this PR publishes are actually appropriate for public release — the data migration trusts that this review is where that confirmation happens.
- **Deploy-time check** (not verifiable locally): confirm `SELECT release_status, count(*) FROM "group" WHERE project_area IS NOT NULL GROUP BY release_status` reads `draft: 56` before and `public: 56` after, on the real target database.
- A11 (authenticated `/ogcapi-internal` mount for staff who need unfiltered access) is a separate ticket/PR/branch that depends on this one merging first.
