### PR TITLE
feat(lexicon): add new organizations to lexicon

### DIFF
--- a/core/lexicon.json
+++ b/core/lexicon.json
@@ -3941,6 +3941,13 @@
       "categories": [
         "organization"
       ],
+      "term": "Lightning Dock Zanskar",
+      "definition": "Lightning Dock Zanskar"
+    },
+    {
+      "categories": [
+        "organization"
+      ],
       "term": "Living World Ministries",
       "definition": "Living World Ministries"
     },
@@ -4228,6 +4235,13 @@
       "categories": [
         "organization"
       ],
+      "term": "Sparrowhawk Farm",
+      "definition": "Sparrowhawk Farm"
+    },
+    {
+      "categories": [
+        "organization"
+      ],
       "term": "Stagecoach Motel",
       "definition": "Stagecoach Motel"
     },
@@ -4371,7 +4385,7 @@
       "term": "USFS, Cibola NF, Magdalena Ranger District",
       "definition": "USFS, Cibola NF, Magdalena Ranger District"
     },
-   {
+    {
       "categories": [
         "organization"
       ],

--- a/core/lexicon.json
+++ b/core/lexicon.json
@@ -4371,6 +4371,13 @@
       "term": "USFS, Cibola NF, Magdalena Ranger District",
       "definition": "USFS, Cibola NF, Magdalena Ranger District"
     },
+   {
+      "categories": [
+        "organization"
+      ],
+      "term": "USFS, Cibola NF, Supervisor's Office",
+      "definition": "USFS, Cibola NF, Supervisor's Office"
+    },
     {
       "categories": [
         "organization"


### PR DESCRIPTION
<!--
feat(lexicon): add new `USFS, Cibola NF, Supervisor's Office`, `Lightning Dock Zanskar`, and
`Sparrowhawk Farm` organizations to lexicon
-->
### **Why**
_This PR addresses the following problem / context:_
- Adds support for importing well inventory records tied to the `USFS, Cibola NF, Supervisor's Office`, `Lightning Dock Zanskar`, and`Sparrowhawk Farm` organizations.

### **How**
_Implementation summary - the following was changed / added / removed:_
- Added `USFS, Cibola NF, Supervisor's Office`, `Lightning Dock Zanskar`, and `Sparrowhawk Farm` as new organization terms in the lexicon.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- None
