### PR TITLE
fix(ogc): isolate public and internal pygeoapi module globals

### DIFF
--- a/core/pygeoapi.py
+++ b/core/pygeoapi.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 import os
 import re
 import sys
@@ -8,6 +8,9 @@ from pathlib import Path
 
 import yaml
 from fastapi import FastAPI
+
+# Consumed by pygeoapi at import time only; see _load_pygeoapi_app.
+_PYGEOAPI_ENV_KEYS = ("PYGEOAPI_CONFIG", "PYGEOAPI_OPENAPI")
 
 THING_COLLECTIONS = [
     {
@@ -404,8 +407,10 @@ def _assert_server_settings_match(
     public_config_path: Path, internal_config_path: Path
 ) -> None:
     # pygeoapi.api.API.__init__ mutates process-wide, module-level globals
-    # (CHARSET, FORMAT_TYPES) that persist across the importlib.reload this
-    # scheme relies on -- whichever mount is constructed last wins for both.
+    # (CHARSET, FORMAT_TYPES). Loading each mount from its own copy of
+    # pygeoapi.starlette_app does not help here, since both copies still
+    # share the one pygeoapi.api module -- whichever mount is constructed
+    # last wins for both.
     # Inert as long as both configs agree on these settings; fail loudly at
     # startup rather than let a future divergence silently corrupt responses
     # on whichever mount lost the race.
@@ -437,12 +442,37 @@ def _generate_openapi(config_path: Path, openapi_path: Path) -> None:
     openapi_path.write_text(openapi, encoding="utf-8")
 
 
-def _load_pygeoapi_app():
+def _load_pygeoapi_app(instance: str, config_path: Path, openapi_path: Path):
+    # pygeoapi.starlette_app resolves PYGEOAPI_CONFIG at import time into a
+    # module-level `api_`, and every route handler looks that name up in the
+    # module's globals at request time. importlib.reload() rebinds those
+    # globals *in place*, so reloading for the second mount retargets the
+    # handlers of the app already built for the first one -- both mounts end
+    # up serving whichever config was loaded last. Give each mount its own
+    # module object so the two sets of globals can never alias.
     module_name = "pygeoapi.starlette_app"
-    if module_name in sys.modules:
-        module = importlib.reload(sys.modules[module_name])
-    else:
-        module = importlib.import_module(module_name)
+    spec = find_spec(module_name)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to locate {module_name} for the {instance} mount.")
+
+    module = importlib.util.module_from_spec(spec)
+    # Registered before exec_module so the module can survive importing itself.
+    sys.modules[f"{module_name}__ocotillo_{instance}"] = module
+
+    previous = {key: os.environ.get(key) for key in _PYGEOAPI_ENV_KEYS}
+    os.environ["PYGEOAPI_CONFIG"] = str(config_path)
+    os.environ["PYGEOAPI_OPENAPI"] = str(openapi_path)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        # These are read only during import, so leaving the last mount's paths
+        # behind would silently decide the config for any later importer.
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
     return module.APP
 
 
@@ -461,10 +491,7 @@ def mount_pygeoapi(app: FastAPI) -> None:
     _write_config(config_path, server_url=_server_url(), include_edr=True)
     _generate_openapi(config_path, openapi_path)
 
-    os.environ["PYGEOAPI_CONFIG"] = str(config_path)
-    os.environ["PYGEOAPI_OPENAPI"] = str(openapi_path)
-
-    pygeoapi_app = _load_pygeoapi_app()
+    pygeoapi_app = _load_pygeoapi_app("public", config_path, openapi_path)
     mount_path = _mount_path()
     app.mount(mount_path, pygeoapi_app)
 
@@ -507,10 +534,7 @@ def mount_pygeoapi_internal(app: FastAPI) -> None:
     _generate_openapi(config_path, openapi_path)
     _assert_server_settings_match(_pygeoapi_dir() / "pygeoapi-config.yml", config_path)
 
-    os.environ["PYGEOAPI_CONFIG"] = str(config_path)
-    os.environ["PYGEOAPI_OPENAPI"] = str(openapi_path)
-
-    pygeoapi_app = _load_pygeoapi_app()
+    pygeoapi_app = _load_pygeoapi_app("internal", config_path, openapi_path)
 
     from core.internal_ogc_auth import InternalOGCAuthMiddleware
 

--- a/tests/test_pygeoapi_mount.py
+++ b/tests/test_pygeoapi_mount.py
@@ -1,50 +1,111 @@
-import types
+"""Isolation guarantees for the public (/ogcapi) and internal (/ogcapi-internal) mounts.
+
+Both mounts are built from the same pygeoapi.starlette_app source, which
+resolves PYGEOAPI_CONFIG at import time into a module-level ``api_`` that
+every route handler reads out of module globals at request time. Loading the
+second mount by reloading that module rebinds those globals in place, which
+silently retargets the already-built first mount -- the public mount then
+serves the unfiltered ogc_internal_* views, defeating the A1
+``release_status = 'public'`` filter. These tests pin the isolation that
+prevents that.
+
+Importing this module builds the app (via the tests package), so both
+runtime config files already exist on disk by the time a test runs.
+"""
+
+import os
+import sys
 
 from core import pygeoapi
 
+PUBLIC_MODULE = "pygeoapi.starlette_app__ocotillo_public"
+INTERNAL_MODULE = "pygeoapi.starlette_app__ocotillo_internal"
 
-def test_load_pygeoapi_app_imports_when_module_not_loaded(monkeypatch):
-    fake_module = types.SimpleNamespace(APP=object())
-    import_calls = []
 
-    def fake_import_module(name):
-        import_calls.append(name)
-        return fake_module
-
-    monkeypatch.delitem(
-        pygeoapi.sys.modules,
-        "pygeoapi.starlette_app",
-        raising=False,
+def _mount_args():
+    public_dir = pygeoapi._pygeoapi_dir()
+    internal_dir = pygeoapi._pygeoapi_dir(
+        "PYGEOAPI_INTERNAL_RUNTIME_DIR", "/tmp/pygeoapi-internal"
     )
-    monkeypatch.setattr(
-        pygeoapi.importlib,
-        "import_module",
-        fake_import_module,
+    return (
+        (
+            "public",
+            public_dir / "pygeoapi-config.yml",
+            public_dir / "pygeoapi-openapi.yml",
+        ),
+        (
+            "internal",
+            internal_dir / "pygeoapi-config.yml",
+            internal_dir / "pygeoapi-openapi.yml",
+        ),
     )
 
-    app = pygeoapi._load_pygeoapi_app()
 
-    assert app is fake_module.APP
-    assert import_calls == ["pygeoapi.starlette_app"]
+def _load_both():
+    # Internal last, matching create_api_app's order -- the order that used
+    # to leave the public mount pointing at ogc_internal_* relations.
+    public, internal = _mount_args()
+    pygeoapi._load_pygeoapi_app(*public)
+    pygeoapi._load_pygeoapi_app(*internal)
+    return sys.modules[PUBLIC_MODULE], sys.modules[INTERNAL_MODULE]
 
 
-def test_load_pygeoapi_app_reloads_when_module_already_loaded(monkeypatch):
-    existing_module = types.SimpleNamespace(APP=object())
-    reloaded_module = types.SimpleNamespace(APP=object())
-    reload_calls = []
+def _provider_tables(api):
+    return {
+        name: resource["providers"][0].get("table")
+        for name, resource in api.config["resources"].items()
+        if resource.get("providers")
+    }
 
-    def fake_reload(module):
-        reload_calls.append(module)
-        return reloaded_module
 
-    monkeypatch.setitem(
-        pygeoapi.sys.modules,
-        "pygeoapi.starlette_app",
-        existing_module,
-    )
-    monkeypatch.setattr(pygeoapi.importlib, "reload", fake_reload)
+def test_each_mount_gets_independent_module_globals():
+    public_module, internal_module = _load_both()
 
-    app = pygeoapi._load_pygeoapi_app()
+    assert public_module is not internal_module
+    # The aliasing that caused the leak: one shared dict, so one shared api_.
+    assert public_module.__dict__ is not internal_module.__dict__
+    assert public_module.api_ is not internal_module.api_
 
-    assert app is reloaded_module.APP
-    assert reload_calls == [existing_module]
+
+def test_public_mount_does_not_resolve_to_internal_relations():
+    public_module, internal_module = _load_both()
+
+    public_tables = _provider_tables(public_module.api_)
+    assert public_tables, "public config exposed no provider-backed collections"
+    leaked = {
+        name: table
+        for name, table in public_tables.items()
+        if table and table.startswith("ogc_internal_")
+    }
+    assert not leaked, f"public mount resolves to internal relations: {leaked}"
+
+    internal_tables = _provider_tables(internal_module.api_)
+    assert internal_tables, "internal config exposed no provider-backed collections"
+    misrouted = {
+        name: table
+        for name, table in internal_tables.items()
+        if table and not table.startswith("ogc_internal_")
+    }
+    assert not misrouted, f"internal mount resolves to public relations: {misrouted}"
+
+
+def test_each_mount_advertises_its_own_server_url():
+    public_module, internal_module = _load_both()
+
+    public_url = public_module.api_.config["server"]["url"]
+    internal_url = internal_module.api_.config["server"]["url"]
+
+    assert public_url != internal_url
+    assert public_url == pygeoapi._server_url()
+    assert internal_url == pygeoapi._internal_server_url()
+
+
+def test_loading_a_mount_restores_config_env_vars():
+    # Leaving the last-loaded mount's paths in the environment would decide
+    # the config for anything that imports pygeoapi later in the process.
+    before = {key: os.environ.get(key) for key in pygeoapi._PYGEOAPI_ENV_KEYS}
+
+    _load_both()
+
+    after = {key: os.environ.get(key) for key in pygeoapi._PYGEOAPI_ENV_KEYS}
+    assert after == before


### PR DESCRIPTION
<!--
- NO TICKET fix(ogc): isolate public and internal pygeoapi module globals
-->
### **Summary**
Fixes a regression on `staging` in which the public, unauthenticated `/ogcapi` mount served the **unfiltered `ogc_internal_*` views**, defeating the `release_status = 'public'` filter that A1 (BDMS-971) added and A11 (BDMS-985) built on top of. Each mount now loads its own copy of the pygeoapi app module so the two can't alias.

### **Why**
_This PR addresses the following problem / context:_
`pygeoapi.starlette_app` resolves `PYGEOAPI_CONFIG` at import time into a module-level `api_`, and every route handler looks that name up in the module's globals when a request arrives. `_load_pygeoapi_app()` built the second mount by calling `importlib.reload()` on that module, which rebinds those globals **in place** — retargeting the handlers already registered on the public app. Whichever mount loaded last won for both, and since `create_api_app()` mounts public first and internal second, the public mount lost.

**This is reachable in production, not only under test.** `main.py` calls `create_api_app()`, the same path the tests exercise. Inspecting a normally-built app shows the public mount's `api_` carrying the internal table prefix and the internal server URL:

```
PUBLIC  /ogcapi:   globals id 4604241088  table ogc_internal_ephemeral_streams  url .../ogcapi-internal
INTERNAL:          globals id 4604241088  table ogc_internal_ephemeral_streams  url .../ogcapi-internal
```

Two distinct Starlette app objects, one shared globals dict.

An earlier pass concluded this was not reproducible outside behave. That was a **false negative**: it compared HTTP status codes, and both mounts return 200 either way. The leak is *which table answers*, not whether one does.

### **Changes**
_Implementation summary - the following was changed / added / removed:_
- **Per-mount module isolation**: `_load_pygeoapi_app()` now takes the instance name and its config paths, and loads a fresh module object via `module_from_spec` / `exec_module` under a distinct `sys.modules` key (`pygeoapi.starlette_app__ocotillo_{public,internal}`) instead of reloading one shared module. The two globals dicts can no longer alias, so each mount keeps its own `api_`.
- **Config env vars scoped to the load**: `PYGEOAPI_CONFIG` / `PYGEOAPI_OPENAPI` are set only around `exec_module` and restored afterward. They're read solely during import, so leaving the last mount's values behind would silently decide the config for any later importer. This was the originally suspected root cause; it's a real latent hazard, but fixing it alone would **not** have fixed this bug, since the aliasing survives regardless of env state.
- **Regression coverage**: `tests/test_pygeoapi_mount.py` now asserts the property that actually matters — no public collection resolves to an `ogc_internal_` relation (and vice versa), each mount gets independent module globals and its own `api_`, each advertises its own server URL, and the env vars come back clean. The two tests these replace asserted the `importlib.reload` behaviour itself, i.e. they pinned the defect, which is why it shipped unnoticed.
- **Stale comment corrected**: the note in `_assert_server_settings_match` described the reload scheme this PR removes.

### **Verification**
- `behave --tags=@A1` — **5/5** passing, from 3 passed / 1 failed / 1 error.
- `behave --tags=@A11` — **6/6** passing, unchanged.
- Full `pytest` suite: **687 passed**, 81 skipped, 0 failed.
- Full `behave` suite compared against the pre-fix baseline on the same rebuilt test DB: 91 → **94** scenarios passing, 6 → **4** failing, 79 → 78 errors. Strict improvement, nothing regressed. The 4 remaining failures are all in `water-level-csv.feature`, pre-existing and unrelated; the errors are undefined steps for unimplemented Sprint 1 tickets.
- **New tests confirmed to fail 4/4 against the pre-fix implementation** — verified by stashing the fix and re-running, so this isn't coverage that only passes after the fact.
- Direct inspection of the built app confirming public → `ogc_*` / internal → `ogc_internal_*`, with distinct globals and distinct `api_` objects.

### **Notes**
_Any special considerations, workarounds, or follow-up work to note?_
- **A2 (BDMS-972) is stacked on this PR and should merge after it.** Not a code dependency. A2's changes work fine without this fix, and its own scenarios pass either way. But A2 branched from the same commit (ce45b919), so it inherits the bug and its CI is red for reasons that have nothing to do with A2: under CI's tag selection A2 currently reports 68 passed / 1 failed / 1 error, and rebased onto this branch reports 70 passed / 0 failed. Rebase is clean, no conflicts, despite both branches touching core/pygeoapi.py.
- **Deployment exposure**: staging only, and reviewed as non-urgent. staging-deploy-2026-08-03T21-51-39+0000 points at ce45b919, the commit this PR fixes, and no newer staging deploy tag exists — so staging has been serving non-public records from the public /ogcapi endpoint since 2026-08-03. This was assessed and does not require an expedited deploy. Production is unaffected for a structural reason rather than a coincidental one: the latest release tag (v1.2.1, 2026-07-30) predates the internal mount, and mount_pygeoapi_internal does not exist in it, so there is no second module load to alias against. Recorded here so the exposure window is documented rather than rediscovered later.
- **Behave showed two symptoms, one cause.** Scenario 88 errored with `UndefinedTable` because `@A1` downgrades past the migration that creates the internal views, so the leaked view was missing. Scenario 44 failed an assertion because the view was present and returned a `draft` `water_wells` record — the production-shaped form of the bug. Scenario 44 was isolated independently before the fix, not assumed to share a cause.
- **`_assert_server_settings_match` is still required.** It guards a *separate* shared-global hazard: `pygeoapi.api.API.__init__` mutates `CHARSET` / `FORMAT_TYPES`, and both module copies still share the one `pygeoapi.api` module. Per-mount isolation does not address that, so the guard stays.
- Unrelated, noted in passing: `tests/test_chemistry_drive.py` and `tests/test_chemistry_lims.py` fail to collect because `openpyxl` is missing from the local venv. Pre-existing env drift, excluded from the runs above rather than worked around.
