### PR TITLE
feat(geothermal): free-text search on the well list endpoint

### DIFF
--- a/api/geothermal.py
+++ b/api/geothermal.py
@@ -25,7 +25,7 @@ under ``/thing`` so the URL is stable across that swap.
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from fastapi_pagination.ext.sqlalchemy import paginate
 from starlette.status import HTTP_200_OK, HTTP_404_NOT_FOUND
 
@@ -52,13 +52,25 @@ def get_geothermal_wells(
     session: session_dependency,
     county: Optional[str] = None,
     name_contains: Optional[str] = None,
+    q: Optional[str] = Query(
+        None,
+        description=(
+            "Free-text search across well name, API, well number, operator and "
+            "county. Whitespace-separated words are ANDed, so each word added "
+            "narrows the result. Case-insensitive substring match."
+        ),
+    ),
 ) -> CustomPage[GeothermalWellResponse]:
     """List geothermal wells.
 
     NOTE: sourced from the legacy NM_Wells mirror (NMW_WellHeaders where
     GthrmExist is set). Will be re-pointed at the thing table post-transform.
+
+    ``q`` is what the UI well picker uses: the catalogue is far too large to
+    choose from by scrolling, so the term is matched server-side and the total
+    reported by the pagination envelope is the size of the match set.
     """
-    sql = get_geothermal_wells_query(county=county, name_contains=name_contains)
+    sql = get_geothermal_wells_query(county=county, name_contains=name_contains, q=q)
     return paginate(query=sql, conn=session, transformer=geothermal_wells_transformer)
 
 

--- a/services/geothermal_helper.py
+++ b/services/geothermal_helper.py
@@ -27,7 +27,7 @@ this helper is what makes that swap a one-file change.
 
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from db.nmw_legacy import NMW_WellHeaders, NMW_WellLocations
 from schemas.geothermal import GeothermalWellResponse
@@ -67,9 +67,40 @@ def _to_response(header: NMW_WellHeaders, location: NMW_WellLocations | None):
     )
 
 
+# Columns a free-text term is matched against. Everything a person might use
+# to refer to a well: what it is called, how it is identified, and who ran it.
+_SEARCH_COLUMNS = (
+    NMW_WellHeaders.cur_well_nam,
+    NMW_WellHeaders.api,
+    NMW_WellHeaders.cur_well_num,
+    NMW_WellHeaders.cur_operatr,
+    NMW_WellLocations.county,
+)
+
+
+def _search_clauses(q: str):
+    """One clause per whitespace-separated word, each matching any column.
+
+    Words are ANDed so that adding a word narrows the result — "jemez 1"
+    returns a subset of "jemez" rather than everything matching either. ILIKE
+    wildcards in the term are escaped so a stray % does not silently widen the
+    search to everything.
+    """
+    clauses = []
+    for word in q.split():
+        pattern = "%{}%".format(
+            word.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
+        clauses.append(
+            or_(*[column.ilike(pattern, escape="\\") for column in _SEARCH_COLUMNS])
+        )
+    return clauses
+
+
 def get_geothermal_wells_query(
     county: str | None = None,
     name_contains: str | None = None,
+    q: str | None = None,
 ):
     """Build the list query; returned as a SQLAlchemy select for pagination."""
     sql = _base_query()
@@ -77,6 +108,9 @@ def get_geothermal_wells_query(
         sql = sql.where(NMW_WellLocations.county == county)
     if name_contains:
         sql = sql.where(NMW_WellHeaders.cur_well_nam.ilike(f"%{name_contains}%"))
+    if q and q.strip():
+        for clause in _search_clauses(q.strip()):
+            sql = sql.where(clause)
     return sql.order_by(NMW_WellHeaders.cur_well_nam)
 
 

--- a/tests/test_geothermal_well_search.py
+++ b/tests/test_geothermal_well_search.py
@@ -1,0 +1,99 @@
+# ===============================================================================
+# Copyright 2026 ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""Free-text search on the geothermal well list query.
+
+The UI well picker cannot offer the catalogue as a scrollable list, so it sends
+a term and relies on the server to narrow it. These tests compile the query and
+assert its shape, which needs no database.
+"""
+
+from services.geothermal_helper import get_geothermal_wells_query
+
+# Columns `q` is matched against, by their legacy NM_Wells names.
+SEARCH_COLUMNS = ("CurWellNam", "API", "CurWellNum", "CurOperatr", "County")
+
+
+def compiled(**kwargs) -> str:
+    sql = get_geothermal_wells_query(**kwargs)
+    return str(sql.compile(compile_kwargs={"literal_binds": True}))
+
+
+def test_no_search_term_adds_no_predicate():
+    """An empty picker lists wells; it must not search for nothing."""
+    baseline = compiled()
+
+    assert compiled(q=None) == baseline
+    assert compiled(q="") == baseline
+    assert compiled(q="   ") == baseline
+    assert "lower" not in baseline.lower() or "ilike" not in baseline.lower()
+
+
+def test_term_matches_every_search_column():
+    sql = compiled(q="jemez")
+
+    for column in SEARCH_COLUMNS:
+        assert column in sql, f"{column} is not searched"
+    assert sql.lower().count("%jemez%") == len(SEARCH_COLUMNS)
+
+
+def test_term_is_case_insensitive_substring():
+    sql = compiled(q="jemez").lower()
+
+    # ILIKE compiles to lower(...) LIKE lower(...) on some dialects; either way
+    # the match is a substring wrapped in wildcards, not an equality.
+    assert "%jemez%" in sql
+    assert "like" in sql
+
+
+def test_words_are_anded_so_each_one_narrows():
+    """ "jemez 1" must be a subset of "jemez", not a union."""
+    one_word = compiled(q="jemez")
+    two_words = compiled(q="jemez 1")
+
+    assert "%jemez%" in two_words
+    assert "%1%" in two_words
+    # A second word adds a second bracketed OR group rather than extending the
+    # first, which is what makes the predicates AND together.
+    assert two_words.count("OR") > one_word.count("OR")
+
+
+def test_wildcards_in_the_term_are_escaped():
+    """A stray % must not silently widen the search to the whole catalogue."""
+    sql = compiled(q="50%")
+
+    assert r"%50\%%" in sql
+    assert "ESCAPE" in sql.upper()
+
+    underscore = compiled(q="a_b")
+    assert r"%a\_b%" in underscore
+
+
+def test_search_composes_with_the_existing_filters():
+    sql = compiled(q="jemez", county="Sandoval")
+
+    assert "%jemez%" in sql
+    assert "Sandoval" in sql
+    # The geothermal flag is the base predicate and must survive.
+    assert "GthrmExist" in sql
+
+
+def test_results_stay_ordered_by_name():
+    assert (
+        compiled(q="jemez").rstrip().endswith('ORDER BY "NMW_WellHeaders"."CurWellNam"')
+    )
+
+
+# ============= EOF =============================================


### PR DESCRIPTION
Backend half of BDMS-1133. Frontend: DataIntegrationGroup/OcotilloUI#343.

## Why

The UI well picker for the Records Grid and Temp-Depth log cannot offer this catalogue as a scrollable list. It previously loaded the first 500 wells into a dropdown and silently dropped the rest, so a well that existed but was not listed was indistinguishable from one that did not exist.

Narrowing has to happen server-side, so the pagination envelope's `total` is the size of the *match set* — that is what the picker reports back to the user as "Showing N of M".

## What

`q` on `GET /thing/geothermal-well`, matched case-insensitively as a substring across well name, API, well number, operator, and county (the last via the existing `NMW_WellLocations` join).

- **Words AND.** `jemez 1` returns a subset of `jemez` rather than a union, so each word added narrows.
- **Wildcards escaped.** A stray `%` matches a literal percent instead of silently widening the search to the whole catalogue.
- `county` and `name_contains` are untouched and compose with `q`.
- Ordering by name is preserved.

## Verified against the seeded dev database

| Query | Result |
|---|---|
| no `q` | 8 (baseline) |
| `q=GEOTHERMAL-0002` | 1 — name |
| `q=garza` | 1 — operator |
| `q=30-104` | 1 — API substring |
| `q=sandoval` | 1 — county, via the joined table |
| `q=SANDOVAL` | 1 — case-insensitive |
| `q=geothermal` → `q=geothermal sandoval` | 8 → 1, words AND |
| `q=%` | **0, not 8** — escaping works |
| `q=` blank | 8 — an empty box lists rather than searching for nothing |
| `q=geothermal&county=Sandoval` | 1 — composes |

Plus 7 unit tests that compile the query and assert its shape, so they need no database: every column searched, words ANDed, wildcards escaped, the `GthrmExist` base predicate surviving, ordering preserved. `black` and `flake8` pre-commit hooks pass.

## Note

The route is still backed by the legacy NM_Wells mirror, as the module docstring says. `q` searches the mirror's columns, so it moves with the source when the NM_Wells → `thing` transform lands; the column list in `_SEARCH_COLUMNS` is the only thing that would need repointing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
