### PR TITLE
fix: correct water_wells collection name in README examples and Added time_field(BDMS-973)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ curl http://localhost:8000/ogcapi/collections/locations
 
 ```bash
 curl "http://localhost:8000/ogcapi/collections/locations/items?limit=10&offset=0"
-curl "http://localhost:8000/ogcapi/collections/wells/items?limit=5"
+curl "http://localhost:8000/ogcapi/collections/water_wells/items?limit=5"
 curl "http://localhost:8000/ogcapi/collections/springs/items?limit=5"
 curl "http://localhost:8000/ogcapi/collections/locations/items/123"
 ```
@@ -56,7 +56,7 @@ curl "http://localhost:8000/ogcapi/collections/locations/items/123"
 
 ```bash
 curl "http://localhost:8000/ogcapi/collections/locations/items?bbox=-107.9,33.8,-107.8,33.9"
-curl "http://localhost:8000/ogcapi/collections/wells/items?datetime=2020-01-01/2024-01-01"
+curl "http://localhost:8000/ogcapi/collections/water_wells/items?datetime=2020-01-01/2024-01-01"
 ```
 
 ### Polygon filter (CQL2 text)

--- a/core/pygeoapi.py
+++ b/core/pygeoapi.py
@@ -267,6 +267,7 @@ def _thing_collections_block(
                     "id_field": "id",
                     "table": f"{table_prefix}{collection['id']}",
                     "geom_field": "point",
+                    "time_field": "first_visit_date",
                 }
             ],
         }


### PR DESCRIPTION
### Why

- README examples referenced a wells collection that doesn't exist — both example URLs 404'd (Section 4.6, R7), the first thing a new developer hits when following the docs.
- Correct collection name is water_wells.

### How

- Updated README.md lines 50 & 59: collections/wells/ → collections/water_wells/.
- Discovered the datetime-filtered example still failed (500) after the rename, because no Thing-based collection (water_wells, springs, diversions_surface_water, ephemeral_streams, lakes_ponds_reservoirs) had a time_field configured, so pygeoapi rejected any ?datetime= query.
- Added "time_field": "first_visit_date" in _thing_collections_block (core/pygeoapi.py) — the one date column populated across all five collections — fixing datetime filtering for all of them, not just water_wells.

### Notes

- Verified both README example URLs now return 200 with valid GeoJSON against a local stack.
- well_completion_date was considered as the time_field but is there are many NULL values , so it wasn't usable - Can be discussed.

- ogc_locations collection is untouched — it's set up separately and wasn't part of this bug.
- 2 unrelated tests fail locally (test_ogc_wells_items_and_item, test_ogc_project_areas_items_expose_groups_with_project_areas). Confirmed they fail the same way even without my change — leftover data in the local test database, not caused by this fix.
