### PR TITLE
fix(db): repair EDR water views skipped by a stamped revision

### DIFF
--- a/alembic/versions/b7c8d9e0f1a2_repair_missing_edr_water_views.py
+++ b/alembic/versions/b7c8d9e0f1a2_repair_missing_edr_water_views.py
@@ -1,0 +1,126 @@
+"""repair missing EDR water views
+
+Recreates ogc_waterlevels / ogc_water_chemistry on any database whose
+alembic_version claims z9a0b1c2d3e4 was applied while the views are in fact
+absent.
+
+Why this is needed: the CD run that first carried z9a0b1c2d3e4 to staging
+failed in the Alembic step with "Multiple head revisions are present for given
+argument 'head'". The revision graph was then repaired in-tree (eb89d046,
+8ae9fe18), but the staging database came out the other side stamped past
+z9a0b1c2d3e4 without its DDL ever having executed. Downstream revisions applied
+normally, so nothing surfaced until an EDR query hit the missing relation:
+
+    psycopg2.errors.UndefinedTable: relation "ogc_waterlevels" does not exist
+
+Re-running z9a0b1c2d3e4 is not an option -- alembic_version already lists it,
+and downgrading to it would tear out every revision since. This revision closes
+the hole from the front of the chain instead.
+
+The view SQL is imported from z9a0b1c2d3e4 rather than copied so the repaired
+definition cannot drift from the definition of record.
+
+Idempotent and safe on healthy databases: a view that is already present is
+left untouched, so this is a no-op everywhere except the environments that
+actually skipped the original revision.
+
+Revision ID: b7c8d9e0f1a2
+Revises: f3a1c2b4d5e6
+Create Date: 2026-08-13 13:20:00.000000
+"""
+
+import importlib.util
+from pathlib import Path
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import inspect, text
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c8d9e0f1a2"
+down_revision: Union[str, Sequence[str], None] = "f3a1c2b4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_SOURCE_REVISION = "z9a0b1c2d3e4_add_edr_water_views.py"
+
+
+def _load_source_revision():
+    # The view definitions live in z9a0b1c2d3e4. Importing them keeps this
+    # repair honest: whatever that revision creates is exactly what a database
+    # that skipped it gets back.
+    path = Path(__file__).with_name(_SOURCE_REVISION)
+    if not path.exists():
+        raise RuntimeError(
+            f"Cannot repair the EDR water views: {_SOURCE_REVISION} is missing "
+            "from alembic/versions, so the view definitions of record are "
+            "unavailable."
+        )
+    spec = importlib.util.spec_from_file_location("_edr_water_views", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+VIEW_COMMENTS = {
+    "ogc_waterlevels": (
+        "Public depth-to-water readings (manual + transducer) for EDR."
+    ),
+    "ogc_water_chemistry": "Public water-chemistry analyses (by analyte) for EDR.",
+}
+
+
+def _relkind(view_name: str) -> str | None:
+    bind = op.get_bind()
+    return bind.execute(
+        text("SELECT relkind FROM pg_class WHERE oid = to_regclass(:name)"),
+        {"name": view_name},
+    ).scalar()
+
+
+def _check_required_tables(required_tables: set[str]) -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing = set(inspector.get_table_names(schema="public"))
+    missing = required_tables - existing
+    if missing:
+        raise RuntimeError(
+            "Cannot repair the EDR water views. Missing required tables: "
+            f"{sorted(missing)}"
+        )
+
+
+def _repair_view(view_name: str, create_sql: str) -> None:
+    relkind = _relkind(view_name)
+    if relkind == "v":
+        # Already present and the right kind -- the database applied
+        # z9a0b1c2d3e4 for real. Leave it alone rather than churning DDL that
+        # other objects may depend on.
+        return
+    if relkind is not None:
+        # Present as something other than a plain view (materialized view,
+        # table). That is not a state z9a0b1c2d3e4 or its downstream revisions
+        # produce, so fail loudly instead of silently replacing it.
+        raise RuntimeError(
+            f"Cannot repair {view_name}: it already exists with relkind "
+            f"{relkind!r}, not a plain view. Inspect it by hand before "
+            "re-running this migration."
+        )
+
+    op.execute(text(create_sql))
+    op.execute(text(f"COMMENT ON VIEW {view_name} IS '{VIEW_COMMENTS[view_name]}'"))
+
+
+def upgrade() -> None:
+    source = _load_source_revision()
+    _check_required_tables(set(source.REQUIRED_TABLES))
+
+    _repair_view("ogc_waterlevels", source._create_waterlevels_view())
+    _repair_view("ogc_water_chemistry", source._create_water_chemistry_view())
+
+
+def downgrade() -> None:
+    # Deliberately a no-op. These views belong to z9a0b1c2d3e4; dropping them
+    # here would break EDR on every database that applied that revision
+    # correctly. Downgrading past z9a0b1c2d3e4 removes them.
+    pass


### PR DESCRIPTION
## Problem

Every OGC API - EDR query on staging returns 500:

```
psycopg2.errors.UndefinedTable: relation "ogc_waterlevels" does not exist
  core/edr_provider.py:111 in _fetch
```

Both collections are affected — `waterlevels` and `water_chemistry`, all query patterns (`/locations`, `/instances`, …). They are still advertised in `/ogcapi/collections`, so consumers see a broken contract.

## Cause

The staging database is stamped past `z9a0b1c2d3e4` without that revision's DDL ever having executed.

The CD run carrying that revision to staging [failed in the Alembic step](https://github.com/DataIntegrationGroup/OcotilloAPI/actions/runs/29782854242) with `Multiple head revisions are present for given argument 'head'`. The revision graph was repaired in-tree afterwards (`eb89d046`, `8ae9fe18`), but the database came out the other side with the revision recorded and its views absent. Downstream revisions applied normally, so nothing surfaced until an EDR request hit the missing relation.

Evidence this is a skipped revision and not a connectivity or wrong-database problem:

- Features collections serve fine over the **same** `PYGEOAPI_POSTGRES_*` connection (`water_wells/items`, `bht_measurements/items`, `heat_flow/items` all 200).
- Revisions downstream of `z9a0b1c2d3e4` are applied — the internal OGC mount from `2d3c3a268652` is live.
- No later revision drops the public EDR views; `2d3c3a268652` only mirrors them as `ogc_internal_*`.
- The original revision cannot silently no-op — it raises on missing source tables.

Re-running it is not possible (`alembic_version` already lists it), and downgrading to it would tear out every revision since. This closes the hole from the front of the chain instead, which also self-heals any other environment carrying the same skip.

## Approach

- View SQL is **imported** from `z9a0b1c2d3e4` rather than copied, so the repaired definition cannot drift from the definition of record.
- `_repair_view` checks `pg_class.relkind` first: plain view → left untouched (no DDL churn, no dependency breakage); absent → created with its `COMMENT ON VIEW`; any other relation kind → raises rather than silently replacing it.
- `downgrade()` is deliberately a no-op — the views belong to `z9a0b1c2d3e4`, and dropping them here would break EDR on databases that applied it correctly.
- Guards on the same `REQUIRED_TABLES` as the original.

## Verification

Against `ocotilloapi_test`, end state restored:

| Scenario | Result |
|---|---|
| Healthy DB → `upgrade head` | `pg_get_viewdef` byte-identical before/after — no-op confirmed |
| `downgrade` | Views survive, version steps back |
| Staging state simulated (views dropped, version past `z9a0b1c2d3e4`) | Both views recreated byte-identical to the originals, comments restored |
| Materialized view squatting the name | `RuntimeError: ... already exists with relkind 'm', not a plain view.` |

`tests/test_migration_view_parity.py` — 9 passed.

## After merge

```
curl -s -o /dev/null -w "%{http_code}\n" https://ocotillo-api-staging.newmexicowaterdata.org/ogcapi/collections/waterlevels/locations?f=json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)