### PR TITLE
ci: add a workflow_dispatch job for data migrations

### DIFF
--- a/.github/workflows/data_migrations.yml
+++ b/.github/workflows/data_migrations.yml
@@ -1,0 +1,139 @@
+name: Data Migrations
+
+# Data migrations (data_migrations/migrations/) are not part of CD. The deploy
+# workflows only run `alembic upgrade head`, so a registered data migration sits
+# unapplied until someone runs it by hand against a live database -- which needs
+# Cloud SQL credentials most people do not have locally. This workflow runs them
+# with the same environment secrets the deploys already use.
+#
+# Start with action = status. It prints what is registered, what has been
+# applied, and when. It applies no migration, though it is not strictly
+# read-only: get_status() calls ensure_history_table(), so a database that has
+# never run one gets an empty data_migration_history table created.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
+      action:
+        description: "status (applies nothing) | run-all | run (single migration)"
+        type: choice
+        options:
+          - status
+          - run-all
+          - run
+        default: status
+      migration_id:
+        description: "Migration id -- required when action = run"
+        type: string
+        default: ""
+      include_repeatable:
+        description: "Include repeatable migrations (action = run-all)"
+        type: boolean
+        default: false
+      force:
+        description: "Re-run migrations already recorded as applied"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# One run at a time per environment: these write to a live database, and two
+# concurrent runs could both pass the "already applied" check.
+concurrency:
+  group: data-migrations-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  data-migrations:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Validate inputs
+        run: |
+          if [ "${{ inputs.action }}" = "run" ] && [ -z "${{ inputs.migration_id }}" ]; then
+            echo "::error::action = run requires migration_id."
+            echo "::error::Run this workflow with action = status to list the registered ids."
+            exit 1
+          fi
+          if [ "${{ inputs.action }}" = "status" ] && [ "${{ inputs.force }}" = "true" ]; then
+            echo "::warning::force has no effect on a status check."
+          fi
+
+      - name: Check out source repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Install uv in container
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          version: "latest"
+
+      - name: Authenticate to Google Cloud
+        uses: "google-github-actions/auth@v3"
+        with:
+          credentials_json: ${{ secrets.CLOUD_DEPLOY_SERVICE_ACCOUNT_KEY }}
+
+      - name: Report target
+        run: |
+          echo "Environment: ${{ inputs.environment }}"
+          echo "Database:    ${{ vars.CLOUD_SQL_DATABASE }}"
+          echo "Action:      ${{ inputs.action }}"
+
+      # Runs before the action so the log shows the before/after pair on a
+      # single run, and so a status-only run needs no second step.
+      - name: Status before
+        env:
+          DB_DRIVER: "cloudsql"
+          CLOUD_SQL_INSTANCE_NAME: "${{ secrets.CLOUD_SQL_INSTANCE_NAME }}"
+          CLOUD_SQL_DATABASE: "${{ vars.CLOUD_SQL_DATABASE }}"
+          CLOUD_SQL_USER: "${{ secrets.CLOUD_SQL_USER }}"
+          CLOUD_SQL_IAM_AUTH: true
+        run: uv run --no-dev oco data-migrations status
+
+      - name: Apply migrations
+        if: inputs.action != 'status'
+        env:
+          DB_DRIVER: "cloudsql"
+          CLOUD_SQL_INSTANCE_NAME: "${{ secrets.CLOUD_SQL_INSTANCE_NAME }}"
+          CLOUD_SQL_DATABASE: "${{ vars.CLOUD_SQL_DATABASE }}"
+          CLOUD_SQL_USER: "${{ secrets.CLOUD_SQL_USER }}"
+          CLOUD_SQL_IAM_AUTH: true
+        run: |
+          set -euo pipefail
+
+          args=()
+          if [ "${{ inputs.action }}" = "run" ]; then
+            args=(run "${{ inputs.migration_id }}")
+            if [ "${{ inputs.force }}" = "true" ]; then
+              args+=(--force)
+            fi
+          else
+            args=(run-all)
+            if [ "${{ inputs.include_repeatable }}" = "true" ]; then
+              args+=(--include-repeatable)
+            fi
+            if [ "${{ inputs.force }}" = "true" ]; then
+              args+=(--force)
+            fi
+          fi
+
+          echo "oco data-migrations ${args[*]}"
+          uv run --no-dev oco data-migrations "${args[@]}"
+
+      - name: Status after
+        if: inputs.action != 'status'
+        env:
+          DB_DRIVER: "cloudsql"
+          CLOUD_SQL_INSTANCE_NAME: "${{ secrets.CLOUD_SQL_INSTANCE_NAME }}"
+          CLOUD_SQL_DATABASE: "${{ vars.CLOUD_SQL_DATABASE }}"
+          CLOUD_SQL_USER: "${{ secrets.CLOUD_SQL_USER }}"
+          CLOUD_SQL_IAM_AUTH: true
+        run: uv run --no-dev oco data-migrations status


### PR DESCRIPTION
## Problem

Data migrations in `data_migrations/migrations/` have no CI path. `CD_staging.yml` and `CD_production.yml` run `alembic upgrade head` and stop — nothing ever calls `oco data-migrations run-all`.

So a registered data migration stays unapplied until someone runs it by hand against a live database, which needs Cloud SQL credentials most of the team doesn't have locally. `20260714_0001_publish_project_areas` has been sitting unapplied on staging since July 14 for exactly this reason, which is why the `project_areas` OGC collection is advertised and returns `numberMatched: 0`.

## What this adds

A `workflow_dispatch` workflow that runs data migrations using the same environment secrets the deploys already use — no local credentials involved.

| Input | Purpose |
|---|---|
| `environment` | `staging` / `production` — selects the GitHub Environment and therefore its secrets and any required reviewers |
| `action` | `status` (default, applies nothing) / `run-all` / `run` |
| `migration_id` | Required when `action = run` |
| `include_repeatable` | Passed through to `run-all` |
| `force` | Re-run migrations already recorded as applied |

Details worth knowing:

- **Status before and after.** The action is bracketed by a `status` report, so one run's log shows what changed rather than just "applied 1 migration(s)".
- **`run` without a `migration_id` fails early**, in a validation step before any credential is touched.
- **Concurrency keyed on environment.** These write to a live database; two concurrent runs could both pass the "already applied" check.
- **`status` is not strictly read-only** — `get_status()` calls `ensure_history_table()`, so a database that has never run one gets an empty `data_migration_history` table created. Documented in the workflow header rather than left as a surprise.

## Using it

Run with `action = status` against `staging` first — it lists the registered ids and what has been applied. Then `action = run` with `migration_id = 20260714_0001_publish_project_areas` to publish the project areas.

The runner already gates on `alembic_revision` (`f4a5b6c7d8e9` for that migration, applied on staging) and records to `data_migration_history`, so a second run is a no-op without `--force`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)